### PR TITLE
Feat/top genres update

### DIFF
--- a/components/r-breadcrumb/RBreadcrumb.vue
+++ b/components/r-breadcrumb/RBreadcrumb.vue
@@ -9,7 +9,11 @@ defineProps<{
 <template>
   <UBreadcrumb
     :items="options"
-    :ui="{ list: 'gap-0', item: 'font-normal text-[15px] text-[#999999]' }"
+    :ui="{
+      list: 'gap-2',
+      item: 'font-normal text-[15px] text-[#999999]',
+      separator: 'mx-2',
+    }"
   >
     <template #item-label="{ active, item }">
       <span
@@ -20,7 +24,7 @@ defineProps<{
       </span>
     </template>
     <template #separator>
-      <span class="text-[#999999]">/</span>
+      <span class="text-[#999999] select-none">/</span>
     </template>
   </UBreadcrumb>
 </template>

--- a/components/r-card-status/RCardStatus.vue
+++ b/components/r-card-status/RCardStatus.vue
@@ -1,14 +1,31 @@
 <script setup lang="ts">
-const { item = {} } = defineProps<{
-  item: Record<string, string | number | string[]>;
+interface Genre {
+  id: number;
+  name: string;
+}
+
+interface BookItem {
+  id: string | number;
+  bookmark_type?: string;
+  genres?: Genre[];
+  [key: string]: any;
+}
+
+const { item } = defineProps<{
+  item: BookItem;
 }>();
+
+// Функция для перехода к управлению главами
+const navigateToEditor = () => {
+  navigateTo(`/book/${item.id}/edit`);
+};
 </script>
 
 <template>
   <div class="w-full">
-    <div class="flex items-center justify-end">
+    <div class="flex items-center justify-end gap-2">
       <div
-        class="type w-30 text-center p-5 pt-[6px] pb-[6px] bg-[#0048B8] text-[#FFFFFF] rounded-[6px] font-normal text-sm"
+        class="type w-30 text-center p-5 pt-[6px] pb-[6px] bg-[#0048B8] text-[#FFFFFF] rounded-[6px] font-normal text-sm flex items-center justify-center"
       >
         <slot name="status" />
       </div>
@@ -86,18 +103,35 @@ const { item = {} } = defineProps<{
           </span>
         </template>
 
-        <template
-          v-if="item.rate"
-          #extra
-        >
-          <div class="extra rate">
-            <u-icon
-              mode="svg"
-              name="my-icons:rate"
-            />
+        <template #extra>
+          <div class="flex items-center gap-3">
+            <!-- Кнопка редактирования -->
+            <u-button
+              v-if="item.is_writeable"
+              variant="ghost"
+              size="xs"
+              class="p-1 hover:bg-gray-100 rounded"
+              @click.stop="navigateToEditor"
+            >
+              <u-icon
+                name="i-lucide-pencil"
+                class="w-4 h-4 text-blue-600"
+              />
+            </u-button>
 
-            <div class="text-[#131313] text-lg font-semibold">
-              {{ item.rate }}
+            <!-- Рейтинг -->
+            <div
+              v-if="item.rate"
+              class="extra rate"
+            >
+              <u-icon
+                mode="svg"
+                name="my-icons:rate"
+              />
+
+              <div class="text-[#131313] text-lg font-semibold">
+                {{ item.rate }}
+              </div>
             </div>
           </div>
         </template>
@@ -155,6 +189,7 @@ const { item = {} } = defineProps<{
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 1;
+    line-clamp: 1;
     word-break: break-all;
     overflow-wrap: break-word;
   }

--- a/entities/book/lib/use-chapters-actions/useChaptersActions.ts
+++ b/entities/book/lib/use-chapters-actions/useChaptersActions.ts
@@ -48,8 +48,8 @@ export const useChaptersActions = ({ refresh }: UseChaptersActions) => {
     }
   };
 
-  const edit = () => {
-    toast.add({ title: 'Удалено', color: 'primary' });
+  const edit = (item: Chapter) => {
+    navigateTo(`/chapter/${item.id}/editor`);
   };
 
   const options = (item: Chapter): DropdownMenuItem[] => [
@@ -57,7 +57,7 @@ export const useChaptersActions = ({ refresh }: UseChaptersActions) => {
       label: 'Редактировать',
       icon: 'i-lucide-edit',
       color: 'info',
-      onSelect: () => edit(),
+      onSelect: () => edit(item),
     },
     {
       label: item.is_public ? 'Заблокировать' : 'Разблокировать',

--- a/entities/book/ui/index.ts
+++ b/entities/book/ui/index.ts
@@ -5,3 +5,4 @@ export { ItemChapter } from './item-chapter';
 export { ModalAgeRate } from './modal-age-rate';
 export { ModalNewChapter } from './modal-new-chapter';
 export { ModalActionChapter } from './modal-action-chapter';
+export { ModalNewBook } from './modal-new-book';

--- a/entities/book/ui/modal-new-book/ModalNewBook.vue
+++ b/entities/book/ui/modal-new-book/ModalNewBook.vue
@@ -1,0 +1,245 @@
+<script setup lang="ts">
+import { z } from 'zod';
+
+interface Props {
+  modelValue?: boolean;
+}
+
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'created', book: any): void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: false,
+});
+
+const emit = defineEmits<Emits>();
+
+const open = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value),
+});
+
+// Форма создания книги
+const form = reactive({
+  title: '',
+  description: '',
+  status: 'В процессе',
+  year: new Date().getFullYear(),
+  genre_ids: [] as string[],
+});
+
+// Состояние загрузки
+const isLoading = ref(false);
+const error = ref('');
+
+// Получение списка жанров
+const { data: genres } = await useFetch('/api/genres', {
+  default: () => [],
+});
+
+const genreOptions = computed(
+  () =>
+    genres.value?.map((genre: any) => ({
+      label: genre.name,
+      value: genre.id,
+    })) || [],
+);
+
+const statusOptions = [
+  { label: 'В процессе', value: 'В процессе' },
+  { label: 'Завершенный', value: 'Завершенный' },
+  { label: 'Заморожено', value: 'Заморожено' },
+  { label: 'Заброшен', value: 'Заброшен' },
+];
+
+// Валидация формы
+const schema = z.object({
+  title: z.string().min(1, 'Название обязательно'),
+  description: z.string().optional(),
+  status: z.string(),
+  year: z
+    .number()
+    .min(1900)
+    .max(new Date().getFullYear() + 10),
+  genre_ids: z.array(z.string()).optional(),
+});
+
+const isFormValid = computed(() => {
+  try {
+    schema.parse(form);
+    return true;
+  } catch {
+    return false;
+  }
+});
+
+// Создание книги
+const createBook = async () => {
+  if (!isFormValid.value) return;
+
+  isLoading.value = true;
+  error.value = '';
+
+  try {
+    const response = await $fetch('/api/book/create', {
+      method: 'POST',
+      body: form,
+    });
+
+    if (response.success) {
+      emit('created', response.book);
+      open.value = false;
+      resetForm();
+
+      // Перенаправление на страницу редактирования
+      await navigateTo(`/book/${response.book.id}/edit`);
+    }
+  } catch (err: any) {
+    console.error('Ошибка создания книги:', err);
+    error.value = err.data?.message || 'Произошла ошибка при создании книги';
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+// Сброс формы
+const resetForm = () => {
+  form.title = '';
+  form.description = '';
+  form.status = 'В процессе';
+  form.year = new Date().getFullYear();
+  form.genre_ids = [];
+  error.value = '';
+};
+
+// Закрытие модального окна
+const closeModal = () => {
+  open.value = false;
+  resetForm();
+};
+</script>
+
+<template>
+  <u-modal
+    v-model:open="open"
+    :ui="{
+      content:
+        'grid gap-4 rounded-[10px] divide-y-0 p-7 max-sm:max-w-[calc(100vw-8px)] sm:max-w-2xl max-h-[90vh] overflow-y-auto',
+    }"
+  >
+    <u-button
+      color="info"
+      class="text-sm font-bold rounded-[10px]"
+      size="lg"
+    >
+      Создать книгу
+    </u-button>
+
+    <template #content>
+      <div class="flex flex-wrap items-center justify-between mb-4">
+        <span class="font-bold text-[22px]">Создать новую книгу</span>
+      </div>
+
+      <!-- Ошибка -->
+      <div
+        v-if="error"
+        class="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded"
+      >
+        {{ error }}
+      </div>
+
+      <form
+        @submit.prevent="createBook"
+        class="space-y-4"
+      >
+        <!-- Название -->
+        <div class="grid gap-1">
+          <label class="text-[15px] font-medium">Название книги *</label>
+          <u-input
+            v-model="form.title"
+            placeholder="Введите название книги"
+            class="rounded-[10px]"
+            size="lg"
+            required
+          />
+        </div>
+
+        <!-- Описание -->
+        <div class="grid gap-1">
+          <label class="text-[15px] font-medium">Описание</label>
+          <u-textarea
+            v-model="form.description"
+            placeholder="Краткое описание книги"
+            class="rounded-[10px]"
+            :rows="3"
+          />
+        </div>
+
+        <!-- Статус и год -->
+        <div class="grid gap-4 grid-cols-1 md:grid-cols-2">
+          <div class="grid gap-1">
+            <label class="text-[15px] font-medium">Статус</label>
+            <u-select
+              v-model="form.status"
+              :options="statusOptions"
+              class="rounded-[10px]"
+              size="lg"
+            />
+          </div>
+
+          <div class="grid gap-1">
+            <label class="text-[15px] font-medium">Год</label>
+            <u-input
+              v-model.number="form.year"
+              type="number"
+              :min="1900"
+              :max="new Date().getFullYear() + 10"
+              class="rounded-[10px]"
+              size="lg"
+            />
+          </div>
+        </div>
+
+        <!-- Жанры -->
+        <div class="grid gap-1">
+          <label class="text-[15px] font-medium">Жанры</label>
+          <u-select-menu
+            v-model="form.genre_ids"
+            :options="genreOptions"
+            multiple
+            placeholder="Выберите жанры"
+            class="rounded-[10px]"
+          />
+        </div>
+
+        <!-- Кнопки -->
+        <div class="flex gap-2 pt-4">
+          <u-button
+            type="button"
+            variant="outline"
+            color="neutral"
+            class="rounded-[10px] flex-1"
+            size="lg"
+            @click="closeModal"
+            :disabled="isLoading"
+          >
+            Отмена
+          </u-button>
+
+          <u-button
+            type="submit"
+            color="info"
+            class="rounded-[10px] flex-1 font-bold"
+            size="lg"
+            :loading="isLoading"
+            :disabled="!isFormValid || isLoading"
+          >
+            Создать книгу
+          </u-button>
+        </div>
+      </form>
+    </template>
+  </u-modal>
+</template>

--- a/entities/book/ui/modal-new-book/index.ts
+++ b/entities/book/ui/modal-new-book/index.ts
@@ -1,0 +1,1 @@
+export { default as ModalNewBook } from './ModalNewBook.vue';

--- a/entities/catalog/consts.ts
+++ b/entities/catalog/consts.ts
@@ -1,4 +1,5 @@
 export enum Status {
+  'all' = 'Все',
   'discarded' = 'Заброшен',
   'done' = 'Завершенный',
   'frozen' = 'Заморожено',

--- a/knex.js
+++ b/knex.js
@@ -15,8 +15,10 @@ export default {
   },
   migrations: {
     directory: __dirname + '/migrations',
+    loadExtensions: ['.js'],
   },
   seeds: {
     directory: __dirname + '/seeds',
+    loadExtensions: ['.js'],
   },
 };

--- a/migrations/20241206000000_add_typography_settings_to_book.js
+++ b/migrations/20241206000000_add_typography_settings_to_book.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function(knex) {
+  await knex.schema.alterTable('book', (table) => {
+    table.text('typography_settings').nullable().comment('JSON настройки типографики для книги');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function(knex) {
+  await knex.schema.alterTable('book', (table) => {
+    table.dropColumn('typography_settings');
+  });
+};

--- a/migrations/20250104000003_create_rotation_state.js
+++ b/migrations/20250104000003_create_rotation_state.js
@@ -3,29 +3,58 @@
  * @param {import('knex').Knex} knex
  * @returns {Promise<void>}
  */
-exports.up = function (knex) {
+export async function up(knex) {
   return knex.schema.createTable('rotation_state', function (table) {
     table.increments('id').primary();
-    table.string('rotation_key', 50).notNullable().unique().comment('Unique key for rotation type (e.g., novelties)');
-    table.integer('current_offset').defaultTo(0).notNullable().comment('Current position in rotation cycle');
-    table.integer('total_items').defaultTo(0).notNullable().comment('Total number of items in rotation');
-    table.integer('items_per_page').defaultTo(4).notNullable().comment('Number of items per page');
-    table.timestamp('last_updated').defaultTo(knex.fn.now()).comment('Last time rotation was updated');
-    table.timestamp('cycle_started_at').defaultTo(knex.fn.now()).comment('When current cycle started');
-    table.integer('cycle_count').defaultTo(0).notNullable().comment('Number of completed cycles');
-    table.json('metadata').nullable().comment('Additional metadata for rotation');
+    table
+      .string('rotation_key', 50)
+      .notNullable()
+      .unique()
+      .comment('Unique key for rotation type (e.g., novelties)');
+    table
+      .integer('current_offset')
+      .defaultTo(0)
+      .notNullable()
+      .comment('Current position in rotation cycle');
+    table
+      .integer('total_items')
+      .defaultTo(0)
+      .notNullable()
+      .comment('Total number of items in rotation');
+    table
+      .integer('items_per_page')
+      .defaultTo(4)
+      .notNullable()
+      .comment('Number of items per page');
+    table
+      .timestamp('last_updated')
+      .defaultTo(knex.fn.now())
+      .comment('Last time rotation was updated');
+    table
+      .timestamp('cycle_started_at')
+      .defaultTo(knex.fn.now())
+      .comment('When current cycle started');
+    table
+      .integer('cycle_count')
+      .defaultTo(0)
+      .notNullable()
+      .comment('Number of completed cycles');
+    table
+      .json('metadata')
+      .nullable()
+      .comment('Additional metadata for rotation');
     table.timestamps(true, true);
 
     // Indexes for performance
     table.index(['rotation_key'], 'idx_rotation_state_key');
     table.index(['last_updated'], 'idx_rotation_state_updated');
   });
-};
+}
 
 /**
  * @param {import('knex').Knex} knex
  * @returns {Promise<void>}
  */
-exports.down = function (knex) {
+export async function down(knex) {
   return knex.schema.dropTable('rotation_state');
-};
+}

--- a/migrations/20250806_add_search_indexes.js
+++ b/migrations/20250806_add_search_indexes.js
@@ -8,73 +8,73 @@ export const up = async (knex) => {
 
   // 1. Создаем GIN индекс для полнотекстового поиска по названию книги
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_name_gin 
+    CREATE INDEX IF NOT EXISTS idx_book_name_gin
     ON book USING gin(to_tsvector('russian', name))
   `);
 
   // 2. Создаем GIN индекс для полнотекстового поиска по альтернативному названию
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_alt_name_gin 
+    CREATE INDEX IF NOT EXISTS idx_book_alt_name_gin
     ON book USING gin(to_tsvector('russian', COALESCE(alt_name, '')))
   `);
 
   // 3. Создаем GIN индекс для полнотекстового поиска по описанию
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_description_gin 
+    CREATE INDEX IF NOT EXISTS idx_book_description_gin
     ON book USING gin(to_tsvector('russian', COALESCE(description, '')))
   `);
 
   // 4. Создаем индекс для поиска по имени автора
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_author_name_gin 
+    CREATE INDEX IF NOT EXISTS idx_author_name_gin
     ON author USING gin(to_tsvector('russian', name))
   `);
 
   // 5. Создаем составной индекс для быстрого поиска по статусу и типу
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_status_type 
+    CREATE INDEX IF NOT EXISTS idx_book_status_type
     ON book (status, type)
   `);
 
   // 6. Создаем индекс для сортировки по дате обновления
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_updated_at 
+    CREATE INDEX IF NOT EXISTS idx_book_updated_at
     ON book (updated_at DESC)
   `);
 
   // 7. Создаем индекс для сортировки по рейтингу
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_rate 
+    CREATE INDEX IF NOT EXISTS idx_book_rate
     ON book (rate DESC) WHERE rate IS NOT NULL
   `);
 
   // 8. Создаем индекс для поиска по году
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_year 
+    CREATE INDEX IF NOT EXISTS idx_book_year
     ON book (year) WHERE year IS NOT NULL
   `);
 
   // 9. Создаем индекс для связи книга-автор (если еще не существует)
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_author_id 
+    CREATE INDEX IF NOT EXISTS idx_book_author_id
     ON book (author_id)
   `);
 
   // 10. Создаем индекс для связи книга-переводчик
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_translator_id 
+    CREATE INDEX IF NOT EXISTS idx_book_translator_id
     ON book (translator_id)
   `);
 
   // 11. Создаем функциональный индекс для case-insensitive поиска по названию
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_book_name_lower 
+    CREATE INDEX IF NOT EXISTS idx_book_name_lower
     ON book (LOWER(name))
   `);
 
   // 12. Создаем функциональный индекс для case-insensitive поиска по имени автора
   await knex.raw(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_author_name_lower 
+    CREATE INDEX IF NOT EXISTS idx_author_name_lower
     ON author (LOWER(name))
   `);
 
@@ -87,7 +87,7 @@ export const down = async (knex) => {
   // Удаляем все созданные индексы
   const indexes = [
     'idx_book_name_gin',
-    'idx_book_alt_name_gin', 
+    'idx_book_alt_name_gin',
     'idx_book_description_gin',
     'idx_author_name_gin',
     'idx_book_status_type',
@@ -97,11 +97,11 @@ export const down = async (knex) => {
     'idx_book_author_id',
     'idx_book_translator_id',
     'idx_book_name_lower',
-    'idx_author_name_lower'
+    'idx_author_name_lower',
   ];
 
   for (const index of indexes) {
-    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${index}`);
+    await knex.raw(`DROP INDEX IF EXISTS ${index}`);
   }
 
   console.log('✅ Индексы поиска удалены');

--- a/migrations/20250808_update_genre_names.js
+++ b/migrations/20250808_update_genre_names.js
@@ -1,0 +1,81 @@
+/**
+ * Миграция: заменить заглушки жанров на реальные названия
+ * - Обновляет строки, где name LIKE 'Жанр%' (или точно 'Жанр')
+ * - Заполняет по порядку из списка genreNames, начиная с id=1 и далее
+ * - Не трогает уже осмысленные имена
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function up(knex) {
+  const genreNames = [
+    'Фэнтези',
+    'Приключения',
+    'Комедия',
+    'Романтика',
+    'Драма',
+    'Ужасы',
+    'Триллер',
+    'Детектив',
+    'Научная фантастика',
+    'Повседневность',
+    'Боевые искусства',
+    'История',
+    'Психология',
+    'Спорт',
+    'Сёнэн',
+    'Сейнен',
+    'Сёдзё',
+    'Дзёсэй',
+    'Исэкай',
+    'Мистика',
+  ];
+
+  // Получаем все жанры по id и имени
+  const rows = await knex('genre').select(['id', 'name']).orderBy('id', 'asc');
+
+  // Собираем список id, которые сейчас содержат заглушки
+  const placeholderRegex = /^Жанр(\s+\d+)?$/i;
+
+  const updates = [];
+  let nameIndex = 0;
+
+  for (const row of rows) {
+    const isPlaceholder = placeholderRegex.test((row.name || '').trim());
+    if (!isPlaceholder) continue;
+
+    if (nameIndex < genreNames.length) {
+      updates.push({ id: row.id, name: genreNames[nameIndex] });
+      nameIndex += 1;
+    }
+  }
+
+  // Применяем обновления пакетно
+  for (const u of updates) {
+    await knex('genre').where({ id: u.id }).update({ name: u.name });
+  }
+};
+
+/**
+ * Откат: возвращаем заглушки в исходном детерминированном виде 'Жанр N'
+ * Важно: делаем это только для тех записей, которые входят в первые N по id,
+ * чтобы избежать переименования кастомных значений, созданных после миграции.
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function down(knex) {
+  const rows = await knex('genre').select(['id']).orderBy('id', 'asc');
+
+  // Считаем, сколько первых жанров мы потенциально переименовывали в up
+  const limit = 20; // длина массива genreNames выше
+
+  let counter = 1;
+  for (const row of rows) {
+    if (counter > limit) break;
+    await knex('genre').where({ id: row.id }).update({ name: `Жанр ${counter}` });
+    counter += 1;
+  }
+};
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "nuxt dev --clear",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "migration": "knex migrate:latest --knexfile knex.js",
+    "migration": "node scripts/migrate.js",
     "reset": "knex migrate:rollback --all --knexfile knex.js",
     "seed": "knex seed:run --knexfile knex.js",
     "postinstall": "nuxt prepare"

--- a/pages/book/[id]/typography-editor.vue
+++ b/pages/book/[id]/typography-editor.vue
@@ -1,0 +1,334 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: ['auth'],
+});
+
+const route = useRoute();
+const bookId = route.params.id as string;
+
+const ROUTES = [
+  { label: 'Главная', to: '/' },
+  { label: 'Профиль', to: '/profile' },
+  { label: 'Мои работы', to: '/my-works' },
+  { label: 'Главы', to: `/book/${bookId}/edit` },
+  { label: 'Редактор типографики', to: `/book/${bookId}/typography-editor` },
+];
+
+// Загрузка данных книги
+const { data: book } = await useFetch(`/api/book/${bookId}`);
+
+// Загрузка существующих настроек типографики
+const { data: existingSettings } = await useFetch(
+  `/api/book/${bookId}/typography`,
+);
+
+// Настройки типографики с загруженными значениями или значениями по умолчанию
+const typographySettings = reactive({
+  font: existingSettings.value?.font || 'Georgia',
+  fontSize: existingSettings.value?.fontSize || 16,
+  lineHeight: existingSettings.value?.lineHeight || 1.5,
+  letterSpacing: existingSettings.value?.letterSpacing || 0,
+  wordSpacing: existingSettings.value?.wordSpacing || 0,
+  textAlign: existingSettings.value?.textAlign || 'justify',
+  marginTop: existingSettings.value?.marginTop || 20,
+  marginBottom: existingSettings.value?.marginBottom || 20,
+  paragraphIndent: existingSettings.value?.paragraphIndent || 20,
+});
+
+// Опции шрифтов
+const fontOptions = [
+  { label: 'Georgia', value: 'Georgia' },
+  { label: 'Times New Roman', value: 'Times New Roman' },
+  { label: 'Arial', value: 'Arial' },
+  { label: 'Helvetica', value: 'Helvetica' },
+  { label: 'Verdana', value: 'Verdana' },
+  { label: 'Roboto', value: 'Roboto' },
+];
+
+// Опции выравнивания текста
+const textAlignOptions = [
+  { label: 'По левому краю', value: 'left' },
+  { label: 'По центру', value: 'center' },
+  { label: 'По правому краю', value: 'right' },
+  { label: 'По ширине', value: 'justify' },
+];
+
+// Пример текста для предварительного просмотра
+const sampleText = `Соображения высшего порядка, а также выбранный нами инновационный путь обеспечивает актуальность модели развития. Разнообразный и богатый опыт реализация намеченного плана развития требует от нас анализа дальнейших направлений развития проекта. Значимость этих проблем настолько очевидна, что постоянный количественный рост и сфера нашей активности представляет собой интересный эксперимент проверки всестороннего сбалансированных нововведений! С другой стороны социально-экономическое развитие требует от нас системного анализа всестороннего сбалансированного развития.
+
+Разнообразный и богатый опыт консультация с профессионалами из IT способствует повышению актуальности модели развития. Разнообразный и богатый опыт реализация намеченного плана развития требует от нас анализа дальнейших направлений развития проекта. Значимость этих проблем настолько очевидна, что постоянный количественный рост и сфера нашей активности представляет собой интересный эксперимент проверки всестороннего сбалансированных нововведений!`;
+
+// Вычисляемые стили для предварительного просмотра
+const previewStyles = computed(() => ({
+  fontFamily: typographySettings.font,
+  fontSize: `${typographySettings.fontSize}px`,
+  lineHeight: typographySettings.lineHeight,
+  letterSpacing: `${typographySettings.letterSpacing}px`,
+  wordSpacing: `${typographySettings.wordSpacing}px`,
+  textAlign: typographySettings.textAlign,
+  marginTop: `${typographySettings.marginTop}px`,
+  marginBottom: `${typographySettings.marginBottom}px`,
+  textIndent: `${typographySettings.paragraphIndent}px`,
+}));
+
+// Сохранение настроек
+const saveSettings = async () => {
+  try {
+    await $fetch(`/api/book/${bookId}/typography`, {
+      method: 'POST',
+      body: typographySettings,
+    });
+
+    // Показать уведомление об успешном сохранении
+    console.log('Настройки типографики сохранены');
+  } catch (error) {
+    console.error('Ошибка сохранения настроек:', error);
+  }
+};
+
+// Сброс к настройкам по умолчанию
+const resetToDefaults = () => {
+  Object.assign(typographySettings, {
+    font: 'Georgia',
+    fontSize: 16,
+    lineHeight: 1.5,
+    letterSpacing: 0,
+    wordSpacing: 0,
+    textAlign: 'justify',
+    marginTop: 20,
+    marginBottom: 20,
+    paragraphIndent: 20,
+  });
+};
+</script>
+
+<template>
+  <NuxtLayout name="default">
+    <template #breadcrumb>
+      <r-breadcrumb :options="ROUTES" />
+    </template>
+
+    <template #title>
+      <r-header
+        bottom="0"
+        class="uppercase text-[#003386]"
+      >
+        Название главы
+      </r-header>
+    </template>
+
+    <div class="typography-editor">
+      <!-- Панель настроек -->
+      <div class="settings-panel">
+        <div class="settings-header">
+          <h3 class="text-lg font-semibold text-[#003386] mb-4">Настройки</h3>
+        </div>
+
+        <div class="settings-grid">
+          <!-- Шрифт -->
+          <div class="setting-group">
+            <label class="setting-label">Шрифт</label>
+            <USelect
+              v-model="typographySettings.font"
+              :options="fontOptions"
+              size="sm"
+              class="setting-control"
+            />
+          </div>
+
+          <!-- Размер шрифта -->
+          <div class="setting-group">
+            <label class="setting-label">Размер шрифта</label>
+            <div class="flex items-center gap-2">
+              <URange
+                v-model="typographySettings.fontSize"
+                :min="12"
+                :max="24"
+                :step="1"
+                class="flex-1"
+              />
+              <span class="text-sm w-8"
+                >{{ typographySettings.fontSize }}px</span
+              >
+            </div>
+          </div>
+
+          <!-- Высота строк -->
+          <div class="setting-group">
+            <label class="setting-label">Высота строк</label>
+            <div class="flex items-center gap-2">
+              <URange
+                v-model="typographySettings.lineHeight"
+                :min="1"
+                :max="2.5"
+                :step="0.1"
+                class="flex-1"
+              />
+              <span class="text-sm w-8">{{
+                typographySettings.lineHeight.toFixed(1)
+              }}</span>
+            </div>
+          </div>
+
+          <!-- Межстрочное расстояние -->
+          <div class="setting-group">
+            <label class="setting-label">Межстрочное расстояние</label>
+            <div class="flex items-center gap-2">
+              <URange
+                v-model="typographySettings.letterSpacing"
+                :min="-2"
+                :max="5"
+                :step="0.5"
+                class="flex-1"
+              />
+              <span class="text-sm w-8"
+                >{{ typographySettings.letterSpacing }}px</span
+              >
+            </div>
+          </div>
+
+          <!-- Ширина контейнера -->
+          <div class="setting-group">
+            <label class="setting-label">Ширина контейнера</label>
+            <div class="flex items-center gap-2">
+              <URange
+                v-model="typographySettings.wordSpacing"
+                :min="0"
+                :max="10"
+                :step="1"
+                class="flex-1"
+              />
+              <span class="text-sm w-12"
+                >{{ typographySettings.wordSpacing }}px</span
+              >
+            </div>
+          </div>
+        </div>
+
+        <!-- Кнопки действий -->
+        <div class="settings-actions">
+          <UButton
+            size="sm"
+            class="bg-[#0862E0] hover:bg-[#0652C0] text-white rounded-[6px]"
+            @click="saveSettings"
+          >
+            Опубликовать
+          </UButton>
+
+          <UButton
+            variant="outline"
+            size="sm"
+            class="border-gray-300 text-gray-700 rounded-[6px]"
+            @click="resetToDefaults"
+          >
+            Отмена
+          </UButton>
+        </div>
+      </div>
+
+      <!-- Предварительный просмотр -->
+      <div class="preview-panel">
+        <div class="preview-header">
+          <UButton
+            variant="ghost"
+            size="sm"
+            class="text-[#003386] hover:bg-blue-50"
+          >
+            Назад
+          </UButton>
+        </div>
+
+        <div
+          class="preview-content"
+          :style="previewStyles"
+        >
+          <p
+            v-for="(paragraph, index) in sampleText.split('\n\n')"
+            :key="index"
+            class="preview-paragraph"
+          >
+            {{ paragraph }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </NuxtLayout>
+</template>
+
+<style lang="scss" scoped>
+.typography-editor {
+  display: flex;
+  gap: 30px;
+  padding: 30px 0;
+  min-height: calc(100vh - 200px);
+}
+
+.settings-panel {
+  width: 300px;
+  background: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0px 0px 4px 0px #59595940;
+  height: fit-content;
+  position: sticky;
+  top: 30px;
+}
+
+.settings-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.setting-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.setting-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.setting-control {
+  width: 100%;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 30px;
+  padding-top: 20px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.preview-panel {
+  flex: 1;
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0px 0px 4px 0px #59595940;
+  overflow: hidden;
+}
+
+.preview-header {
+  padding: 15px 20px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.preview-content {
+  padding: 40px;
+  background: white;
+  min-height: 600px;
+}
+
+.preview-paragraph {
+  margin-bottom: 1em;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+</style>

--- a/pages/book/create.vue
+++ b/pages/book/create.vue
@@ -1,0 +1,1139 @@
+<script setup lang="ts">
+import { z } from 'zod';
+
+definePageMeta({
+  middleware: ['auth'],
+});
+
+const ROUTES = [
+  { label: 'Главная', to: '/' },
+  { label: 'Профиль', to: '/profile' },
+  { label: 'Мои работы', to: '/my-works' },
+  { label: 'Создание книги', to: '/book/create' },
+];
+
+// Расширенная схема валидации
+const schema = z.object({
+  title: z
+    .string()
+    .min(1, 'Название книги обязательно')
+    .max(200, 'Название не должно превышать 200 символов')
+    .refine(
+      (val) => val.trim().length >= 3,
+      'Название должно содержать минимум 3 символа',
+    ),
+  description: z
+    .string()
+    .min(50, 'Описание должно содержать минимум 50 символов')
+    .max(2000, 'Описание не должно превышать 2000 символов'),
+  genre_ids: z
+    .array(z.string())
+    .min(1, 'Выберите хотя бы один жанр')
+    .max(5, 'Можно выбрать максимум 5 жанров'),
+  age_rating: z.enum(['0+', '6+', '12+', '16+', '18+']),
+  tags: z
+    .string()
+    .optional()
+    .refine(
+      (val) => !val || val.split(',').length <= 10,
+      'Можно указать максимум 10 тегов',
+    ),
+});
+
+type Schema = z.output<typeof schema>;
+
+// Состояние формы
+const state = reactive<Schema>({
+  title: '',
+  description: '',
+  genre_ids: [],
+  age_rating: '16+',
+  tags: '',
+});
+
+// Состояние UI
+const isLoading = ref(false);
+const currentStep = ref(1);
+const totalSteps = 3;
+const showPreview = ref(false);
+const errors = ref<Record<string, string>>({});
+
+// Загрузка жанров
+const { data: genres } = await useFetch('/api/genres');
+
+// Опции возрастного рейтинга с описаниями
+const ageRatingOptions = [
+  {
+    label: '0+',
+    value: '0+',
+    description: 'Для всех возрастов',
+    icon: 'i-lucide-baby',
+  },
+  {
+    label: '6+',
+    value: '6+',
+    description: 'Для детей от 6 лет',
+    icon: 'i-lucide-smile',
+  },
+  {
+    label: '12+',
+    value: '12+',
+    description: 'Для подростков от 12 лет',
+    icon: 'i-lucide-user',
+  },
+  {
+    label: '16+',
+    value: '16+',
+    description: 'Для молодежи от 16 лет',
+    icon: 'i-lucide-users',
+  },
+  {
+    label: '18+',
+    value: '18+',
+    description: 'Только для взрослых',
+    icon: 'i-lucide-shield-alert',
+  },
+];
+
+// Вычисляемые свойства
+const selectedGenres = computed(
+  () =>
+    genres.value?.filter((genre: any) => state.genre_ids.includes(genre.id)) ||
+    [],
+);
+
+const tagsArray = computed(() =>
+  state.tags
+    ? state.tags
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+    : [],
+);
+
+const isStepValid = computed(() => {
+  switch (currentStep.value) {
+    case 1:
+      return state.title.trim().length >= 3 && state.description.length >= 50;
+    case 2:
+      return state.genre_ids.length > 0 && state.genre_ids.length <= 5;
+    case 3:
+      return true; // Последний шаг всегда валиден
+    default:
+      return false;
+  }
+});
+
+const canProceed = computed(() => isStepValid.value && !isLoading.value);
+
+// Методы навигации по шагам
+const nextStep = () => {
+  if (canProceed.value && currentStep.value < totalSteps) {
+    currentStep.value++;
+  }
+};
+
+const prevStep = () => {
+  if (currentStep.value > 1) {
+    currentStep.value--;
+  }
+};
+
+// Валидация в реальном времени
+const validateField = (field: keyof Schema) => {
+  try {
+    const fieldSchema = schema.shape[field];
+    fieldSchema.parse(state[field]);
+    delete errors.value[field];
+  } catch (error: any) {
+    if (error.errors?.[0]?.message) {
+      errors.value[field] = error.errors[0].message;
+    }
+  }
+};
+
+// Обработка отправки формы
+const onSubmit = async () => {
+  try {
+    isLoading.value = true;
+    errors.value = {};
+
+    // Финальная валидация
+    const validatedData = schema.parse(state);
+
+    const response = await $fetch('/api/book/create', {
+      method: 'POST',
+      body: {
+        title: validatedData.title.trim(),
+        description: validatedData.description.trim(),
+        genre_ids: validatedData.genre_ids,
+        age_rating: validatedData.age_rating,
+        tags: validatedData.tags
+          ? validatedData.tags
+              .split(',')
+              .map((tag) => tag.trim())
+              .filter(Boolean)
+          : [],
+      },
+    });
+
+    // Показываем уведомление об успехе
+    const toast = useToast();
+    toast.add({
+      title: 'Книга создана успешно!',
+      description: 'Теперь вы можете добавить главы и настроить оформление',
+      icon: 'i-lucide-check-circle',
+      color: 'success',
+    });
+
+    // Перенаправляем на страницу редактирования
+    await navigateTo(`/book/${response.id}/edit`);
+  } catch (error: any) {
+    console.error('Ошибка создания книги:', error);
+
+    const toast = useToast();
+    toast.add({
+      title: 'Ошибка создания книги',
+      description:
+        error.data?.message ||
+        'Произошла неожиданная ошибка. Попробуйте еще раз.',
+      icon: 'i-lucide-alert-circle',
+      color: 'error',
+    });
+
+    // Если ошибка валидации, показываем детали
+    if (error.data?.errors) {
+      errors.value = error.data.errors;
+    }
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+// Сброс формы
+const resetForm = () => {
+  Object.assign(state, {
+    title: '',
+    description: '',
+    genre_ids: [],
+    age_rating: '16+',
+    tags: '',
+  });
+  currentStep.value = 1;
+  errors.value = {};
+};
+</script>
+
+<template>
+  <NuxtLayout name="default">
+    <template #breadcrumb>
+      <r-breadcrumb :options="ROUTES" />
+    </template>
+
+    <template #title>
+      <div class="flex flex-col">
+        <r-header
+          bottom="0"
+          class="uppercase text-[#003386]"
+        >
+          Создание книги
+        </r-header>
+
+        <!-- Индикатор прогресса -->
+        <div class="flex items-center gap-3 mt-3">
+          <span class="text-sm text-gray-600">
+            Шаг {{ currentStep }} из {{ totalSteps }}
+          </span>
+          <UProgress
+            :value="(currentStep / totalSteps) * 100"
+            class="w-32"
+            color="info"
+          />
+        </div>
+      </div>
+    </template>
+
+    <div class="create-book-container max-w-7xl mx-auto px-4">
+      <!-- Навигация по шагам -->
+      <div class="mb-8">
+        <nav class="flex justify-center">
+          <ol class="flex items-center space-x-4">
+            <li
+              v-for="step in totalSteps"
+              :key="step"
+              class="flex items-center"
+            >
+              <div
+                class="flex items-center justify-center w-10 h-10 rounded-full border-2 transition-all duration-200"
+                :class="{
+                  'bg-[#0862E0] border-[#0862E0] text-white':
+                    step <= currentStep,
+                  'border-gray-300 text-gray-400': step > currentStep,
+                }"
+              >
+                <UIcon
+                  v-if="step < currentStep"
+                  name="i-lucide-check"
+                  class="w-5 h-5"
+                />
+                <span
+                  v-else
+                  class="text-sm font-medium"
+                  >{{ step }}</span
+                >
+              </div>
+
+              <div
+                v-if="step < totalSteps"
+                class="w-16 h-0.5 ml-4 transition-colors duration-200"
+                :class="{
+                  'bg-[#0862E0]': step < currentStep,
+                  'bg-gray-300': step >= currentStep,
+                }"
+              />
+            </li>
+          </ol>
+        </nav>
+
+        <!-- Названия шагов -->
+        <div class="flex justify-center mt-4">
+          <div class="flex space-x-20 text-sm">
+            <span
+              class="transition-colors duration-200"
+              :class="{
+                'text-[#0862E0] font-medium': currentStep === 1,
+                'text-gray-600': currentStep !== 1,
+              }"
+            >
+              Основная информация
+            </span>
+            <span
+              class="transition-colors duration-200"
+              :class="{
+                'text-[#0862E0] font-medium': currentStep === 2,
+                'text-gray-600': currentStep !== 2,
+              }"
+            >
+              Жанры и категории
+            </span>
+            <span
+              class="transition-colors duration-200"
+              :class="{
+                'text-[#0862E0] font-medium': currentStep === 3,
+                'text-gray-600': currentStep !== 3,
+              }"
+            >
+              Финализация
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Контент формы -->
+      <div
+        class="bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden transition-all duration-300 hover:shadow-2xl"
+      >
+        <!-- Шаг 1: Основная информация -->
+        <Transition
+          name="step-transition"
+          mode="out-in"
+        >
+          <div
+            v-if="currentStep === 1"
+            key="step-1"
+            class="p-8 bg-gradient-to-br from-blue-50/50 to-indigo-50/30"
+          >
+            <!-- Заголовок секции с улучшенным дизайном -->
+            <div class="mb-8 text-center">
+              <div
+                class="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-[#0862E0] to-[#003386] rounded-2xl mb-4 shadow-lg"
+              >
+                <UIcon
+                  name="i-lucide-book-open"
+                  class="w-8 h-8 text-white"
+                />
+              </div>
+              <h2
+                class="text-3xl font-bold bg-gradient-to-r from-[#003386] to-[#0862E0] bg-clip-text text-transparent mb-3"
+              >
+                Основная информация о книге
+              </h2>
+              <p
+                class="text-lg text-gray-600 max-w-4xl mx-auto leading-relaxed"
+              >
+                Создайте привлекательное описание вашего произведения.
+                Качественная презентация — ключ к успеху у читателей и первый
+                шаг к популярности вашей книги.
+              </p>
+
+              <!-- Индикатор прогресса заполнения -->
+              <div class="mt-6 flex items-center justify-center gap-4">
+                <div class="flex items-center gap-2">
+                  <div
+                    class="w-3 h-3 rounded-full bg-gradient-to-r from-green-400 to-green-500 shadow-sm"
+                  ></div>
+                  <span class="text-sm text-gray-600"
+                    >Заполнено полей:
+                    {{
+                      Object.values({
+                        title: state.title,
+                        description: state.description,
+                      }).filter((v) => v && v.length > 0).length
+                    }}/2</span
+                  >
+                </div>
+              </div>
+            </div>
+
+            <div class="space-y-8 w-full max-w-none">
+              <!-- Название книги -->
+              <div
+                class="bg-white rounded-2xl p-8 shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300 w-full"
+              >
+                <UFormGroup
+                  label="Название книги"
+                  name="title"
+                  required
+                  :error="errors.title"
+                  class="space-y-3 w-full"
+                >
+                  <template #label>
+                    <div class="flex items-center gap-3 mb-2">
+                      <div
+                        class="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-blue-100 to-blue-200 rounded-xl"
+                      >
+                        <UIcon
+                          name="i-lucide-pen-tool"
+                          class="w-5 h-5 text-[#0862E0]"
+                        />
+                      </div>
+                      <div class="flex-1">
+                        <span class="text-base font-semibold text-gray-800"
+                          >Название книги</span
+                        >
+                        <span class="text-red-500 ml-1">*</span>
+                        <p class="text-sm text-gray-500 mt-1">
+                          Придумайте запоминающееся название, которое отражает
+                          суть произведения
+                        </p>
+                      </div>
+                    </div>
+                  </template>
+
+                  <UInput
+                    v-model="state.title"
+                    placeholder="Например: 'Тайны забытого королевства' или 'Последний рассвет'"
+                    size="lg"
+                    class="!w-full !max-w-none"
+                    :ui="{
+                      base: 'bg-gradient-to-r from-gray-50 to-blue-50/30 border-2 border-gray-200 focus:border-[#0862E0] focus:ring-4 focus:ring-[#0862E0]/20 rounded-xl transition-all duration-300 hover:border-blue-300 focus:bg-white text-lg min-h-[60px] px-6 py-4 !w-full !max-w-none',
+                    }"
+                    @blur="validateField('title')"
+                    @input="validateField('title')"
+                  />
+
+                  <div class="flex justify-between items-center text-sm">
+                    <div class="flex items-center gap-2">
+                      <UIcon
+                        :name="
+                          state.title.length >= 3
+                            ? 'i-lucide-check-circle'
+                            : 'i-lucide-info'
+                        "
+                        :class="
+                          state.title.length >= 3
+                            ? 'text-green-500'
+                            : 'text-gray-400'
+                        "
+                        class="w-4 h-4"
+                      />
+                      <span
+                        :class="
+                          state.title.length >= 3
+                            ? 'text-green-600'
+                            : 'text-gray-500'
+                        "
+                      >
+                        {{
+                          state.title.length >= 3
+                            ? 'Отлично!'
+                            : 'Минимум 3 символа'
+                        }}
+                      </span>
+                    </div>
+                    <span class="text-gray-500 font-mono"
+                      >{{ state.title.length }}/200</span
+                    >
+                  </div>
+                </UFormGroup>
+              </div>
+
+              <!-- Описание -->
+              <div
+                class="bg-white rounded-2xl p-8 shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300 w-full"
+              >
+                <UFormGroup
+                  label="Описание"
+                  name="description"
+                  required
+                  :error="errors.description"
+                  class="space-y-3 w-full"
+                >
+                  <template #label>
+                    <div class="flex items-center gap-3 mb-2">
+                      <div
+                        class="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-purple-100 to-purple-200 rounded-xl"
+                      >
+                        <UIcon
+                          name="i-lucide-file-text"
+                          class="w-5 h-5 text-purple-600"
+                        />
+                      </div>
+                      <div class="flex-1">
+                        <span class="text-base font-semibold text-gray-800"
+                          >Описание книги</span
+                        >
+                        <span class="text-red-500 ml-1">*</span>
+                        <p class="text-sm text-gray-500 mt-1">
+                          Расскажите о сюжете, героях и атмосфере. Заинтригуйте
+                          потенциальных читателей
+                        </p>
+                      </div>
+                    </div>
+                  </template>
+
+                  <UTextarea
+                    v-model="state.description"
+                    placeholder="В далёком королевстве, где магия переплетается с реальностью, молодая волшебница отправляется в опасное путешествие, чтобы спасти свой народ от древнего проклятия"
+                    :rows="10"
+                    class="!w-full !max-w-none"
+                    :ui="{
+                      base: 'bg-gradient-to-r from-gray-50 to-purple-50/30 border-2 border-gray-200 focus:border-purple-400 focus:ring-4 focus:ring-purple-400/20 rounded-xl transition-all duration-300 resize-none hover:border-purple-300 focus:bg-white text-base leading-relaxed min-h-[200px] px-6 py-4 !w-full !max-w-none',
+                    }"
+                    @blur="validateField('description')"
+                    @input="validateField('description')"
+                  />
+
+                  <div class="flex justify-between items-center text-sm">
+                    <div class="flex items-center gap-2">
+                      <UIcon
+                        :name="
+                          state.description.length >= 50
+                            ? 'i-lucide-check-circle'
+                            : 'i-lucide-info'
+                        "
+                        :class="
+                          state.description.length >= 50
+                            ? 'text-green-500'
+                            : 'text-gray-400'
+                        "
+                        class="w-4 h-4"
+                      />
+                      <span
+                        :class="
+                          state.description.length >= 50
+                            ? 'text-green-600'
+                            : 'text-gray-500'
+                        "
+                      >
+                        {{
+                          state.description.length >= 50
+                            ? 'Превосходно!'
+                            : 'Минимум 50 символов'
+                        }}
+                      </span>
+                    </div>
+                    <span class="text-gray-500 font-mono"
+                      >{{ state.description.length }}/2000</span
+                    >
+                  </div>
+
+                  <!-- Подсказки для написания описания -->
+                  <div
+                    class="mt-4 p-4 bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl border border-blue-100"
+                  >
+                    <div class="flex items-start gap-3">
+                      <UIcon
+                        name="i-lucide-lightbulb"
+                        class="w-5 h-5 text-blue-600 mt-0.5"
+                      />
+                      <div>
+                        <h4 class="text-sm font-semibold text-blue-800 mb-2">
+                          Советы для отличного описания:
+                        </h4>
+                        <ul class="text-sm text-blue-700 space-y-1">
+                          <li>• Опишите главного героя и его цель</li>
+                          <li>• Намекните на конфликт или проблему</li>
+                          <li>
+                            • Создайте интригу, но не раскрывайте концовку
+                          </li>
+                          <li>• Передайте атмосферу и настроение книги</li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                </UFormGroup>
+              </div>
+            </div>
+          </div>
+        </Transition>
+
+        <!-- Шаг 2: Жанры и категории -->
+        <Transition
+          name="step-transition"
+          mode="out-in"
+        >
+          <div
+            v-if="currentStep === 2"
+            key="step-2"
+            class="p-8"
+          >
+            <div class="mb-6">
+              <h2 class="text-2xl font-bold text-gray-900 mb-2">
+                Жанры и категории
+              </h2>
+              <p class="text-gray-600">
+                Выберите жанры и возрастной рейтинг. Это поможет читателям найти
+                вашу книгу.
+              </p>
+            </div>
+
+            <div class="space-y-8">
+              <!-- Жанры -->
+              <UFormGroup
+                label="Жанры"
+                name="genre_ids"
+                required
+                :error="errors.genre_ids"
+                class="space-y-4"
+              >
+                <template #label>
+                  <div class="flex items-center gap-2 mb-4">
+                    <UIcon
+                      name="i-lucide-tags"
+                      class="w-4 h-4 text-[#0862E0]"
+                    />
+                    <span class="text-sm font-medium text-gray-700"
+                      >Жанры книги</span
+                    >
+                    <span class="text-red-500">*</span>
+                    <span class="text-xs text-gray-500 ml-2">
+                      (выберите от 1 до 5 жанров)
+                    </span>
+                  </div>
+                </template>
+
+                <!-- Выбранные жанры -->
+                <div
+                  v-if="selectedGenres.length > 0"
+                  class="mb-4"
+                >
+                  <div class="flex flex-wrap gap-2">
+                    <UBadge
+                      v-for="genre in selectedGenres"
+                      :key="genre.id"
+                      color="info"
+                      variant="soft"
+                      class="px-3 py-1 text-sm"
+                    >
+                      {{ genre.name }}
+                      <UButton
+                        icon="i-lucide-x"
+                        size="xs"
+                        color="neutral"
+                        variant="ghost"
+                        class="ml-1 -mr-1"
+                        @click="
+                          state.genre_ids = state.genre_ids.filter(
+                            (id) => id !== genre.id,
+                          )
+                        "
+                      />
+                    </UBadge>
+                  </div>
+                </div>
+
+                <!-- Сетка жанров -->
+                <div
+                  class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3"
+                >
+                  <label
+                    v-for="genre in genres"
+                    :key="genre.id"
+                    class="group relative flex items-center p-4 border-2 rounded-xl cursor-pointer transition-all duration-200 hover:shadow-md"
+                    :class="{
+                      'border-[#0862E0] bg-blue-50': state.genre_ids.includes(
+                        genre.id,
+                      ),
+                      'border-gray-200 bg-white hover:border-gray-300':
+                        !state.genre_ids.includes(genre.id),
+                      'opacity-50 cursor-not-allowed':
+                        state.genre_ids.length >= 5 &&
+                        !state.genre_ids.includes(genre.id),
+                    }"
+                  >
+                    <UCheckbox
+                      :model-value="state.genre_ids.includes(genre.id)"
+                      :disabled="
+                        state.genre_ids.length >= 5 &&
+                        !state.genre_ids.includes(genre.id)
+                      "
+                      class="mr-3"
+                      @update:model-value="
+                        (checked) => {
+                          if (checked && state.genre_ids.length < 5) {
+                            state.genre_ids.push(genre.id);
+                          } else if (!checked) {
+                            const index = state.genre_ids.indexOf(genre.id);
+                            if (index > -1) state.genre_ids.splice(index, 1);
+                          }
+                          validateField('genre_ids');
+                        }
+                      "
+                    />
+                    <span
+                      class="text-sm font-medium transition-colors duration-200"
+                      :class="{
+                        'text-[#0862E0]': state.genre_ids.includes(genre.id),
+                        'text-gray-700': !state.genre_ids.includes(genre.id),
+                      }"
+                    >
+                      {{ genre.name }}
+                    </span>
+                  </label>
+                </div>
+
+                <div class="text-xs text-gray-500 mt-2">
+                  Выбрано: {{ state.genre_ids.length }}/5 жанров
+                </div>
+              </UFormGroup>
+
+              <!-- Возрастной рейтинг -->
+              <UFormGroup
+                label="Возрастной рейтинг"
+                name="age_rating"
+                required
+                class="space-y-4"
+              >
+                <template #label>
+                  <div class="flex items-center gap-2 mb-4">
+                    <UIcon
+                      name="i-lucide-shield-check"
+                      class="w-4 h-4 text-[#0862E0]"
+                    />
+                    <span class="text-sm font-medium text-gray-700"
+                      >Возрастной рейтинг</span
+                    >
+                    <span class="text-red-500">*</span>
+                  </div>
+                </template>
+
+                <div
+                  class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+                >
+                  <label
+                    v-for="option in ageRatingOptions"
+                    :key="option.value"
+                    class="group relative flex items-center p-4 border-2 rounded-xl cursor-pointer transition-all duration-200 hover:shadow-md"
+                    :class="{
+                      'border-[#0862E0] bg-blue-50':
+                        state.age_rating === option.value,
+                      'border-gray-200 bg-white hover:border-gray-300':
+                        state.age_rating !== option.value,
+                    }"
+                  >
+                    <URadio
+                      v-model="state.age_rating"
+                      :value="option.value"
+                      class="mr-3"
+                    />
+                    <div class="flex items-center gap-3">
+                      <UIcon
+                        :name="option.icon"
+                        class="w-5 h-5"
+                        :class="{
+                          'text-[#0862E0]': state.age_rating === option.value,
+                          'text-gray-400': state.age_rating !== option.value,
+                        }"
+                      />
+                      <div>
+                        <div
+                          class="font-medium transition-colors duration-200"
+                          :class="{
+                            'text-[#0862E0]': state.age_rating === option.value,
+                            'text-gray-900': state.age_rating !== option.value,
+                          }"
+                        >
+                          {{ option.label }}
+                        </div>
+                        <div class="text-xs text-gray-500">
+                          {{ option.description }}
+                        </div>
+                      </div>
+                    </div>
+                  </label>
+                </div>
+              </UFormGroup>
+
+              <!-- Теги -->
+              <UFormGroup
+                label="Теги"
+                name="tags"
+                :error="errors.tags"
+                class="space-y-4"
+              >
+                <template #label>
+                  <div class="flex items-center gap-2 mb-4">
+                    <UIcon
+                      name="i-lucide-hash"
+                      class="w-4 h-4 text-[#0862E0]"
+                    />
+                    <span class="text-sm font-medium text-gray-700">Теги</span>
+                    <span class="text-xs text-gray-500 ml-2">
+                      (необязательно, через запятую)
+                    </span>
+                  </div>
+                </template>
+
+                <UInput
+                  v-model="state.tags"
+                  placeholder="фантастика, приключения, магия, дружба"
+                  size="lg"
+                  :ui="{
+                    base: 'bg-gray-50 border-gray-200 focus:border-[#0862E0] focus:ring-[#0862E0] rounded-xl transition-all duration-200',
+                  }"
+                  @blur="validateField('tags')"
+                />
+
+                <!-- Превью тегов -->
+                <div
+                  v-if="tagsArray.length > 0"
+                  class="flex flex-wrap gap-2 mt-3"
+                >
+                  <UBadge
+                    v-for="tag in tagsArray"
+                    :key="tag"
+                    color="neutral"
+                    variant="soft"
+                    class="px-2 py-1 text-xs"
+                  >
+                    #{{ tag }}
+                  </UBadge>
+                </div>
+
+                <div class="text-xs text-gray-500">
+                  Теги помогают читателям найти книги по интересам. Максимум 10
+                  тегов.
+                </div>
+              </UFormGroup>
+            </div>
+          </div>
+        </Transition>
+
+        <!-- Шаг 3: Финализация -->
+        <Transition
+          name="step-transition"
+          mode="out-in"
+        >
+          <div
+            v-if="currentStep === 3"
+            key="step-3"
+            class="p-8"
+          >
+            <div class="mb-6">
+              <h2 class="text-2xl font-bold text-gray-900 mb-2">
+                Проверьте данные и создайте книгу
+              </h2>
+              <p class="text-gray-600">
+                Убедитесь, что все данные указаны корректно. После создания вы
+                сможете добавить главы и настроить оформление.
+              </p>
+            </div>
+
+            <!-- Превью книги -->
+            <div
+              class="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl p-6 border border-blue-100"
+            >
+              <div class="flex items-start gap-6">
+                <!-- Обложка-заглушка -->
+                <div
+                  class="flex-shrink-0 w-32 h-48 bg-gradient-to-br from-[#0862E0] to-[#003386] rounded-lg shadow-lg flex items-center justify-center"
+                >
+                  <div class="text-center text-white p-4">
+                    <UIcon
+                      name="i-lucide-book-open"
+                      class="w-8 h-8 mx-auto mb-2"
+                    />
+                    <div class="text-xs font-medium">
+                      Обложка будет добавлена позже
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Информация о книге -->
+                <div class="flex-1 min-w-0">
+                  <h3 class="text-xl font-bold text-gray-900 mb-2 truncate">
+                    {{ state.title || 'Название книги' }}
+                  </h3>
+
+                  <div class="space-y-3">
+                    <!-- Описание -->
+                    <div>
+                      <h4 class="text-sm font-medium text-gray-700 mb-1">
+                        Описание:
+                      </h4>
+                      <p class="text-sm text-gray-600 line-clamp-3">
+                        {{ state.description || 'Описание книги' }}
+                      </p>
+                    </div>
+
+                    <!-- Жанры -->
+                    <div>
+                      <h4 class="text-sm font-medium text-gray-700 mb-2">
+                        Жанры:
+                      </h4>
+                      <div class="flex flex-wrap gap-1">
+                        <UBadge
+                          v-for="genre in selectedGenres"
+                          :key="genre.id"
+                          color="info"
+                          variant="soft"
+                          size="sm"
+                        >
+                          {{ genre.name }}
+                        </UBadge>
+                      </div>
+                    </div>
+
+                    <!-- Возрастной рейтинг -->
+                    <div class="flex items-center gap-2">
+                      <h4 class="text-sm font-medium text-gray-700">
+                        Возрастной рейтинг:
+                      </h4>
+                      <UBadge
+                        :color="
+                          state.age_rating === '18+'
+                            ? 'error'
+                            : state.age_rating === '16+'
+                              ? 'warning'
+                              : 'success'
+                        "
+                        variant="soft"
+                      >
+                        {{ state.age_rating }}
+                      </UBadge>
+                    </div>
+
+                    <!-- Теги -->
+                    <div v-if="tagsArray.length > 0">
+                      <h4 class="text-sm font-medium text-gray-700 mb-2">
+                        Теги:
+                      </h4>
+                      <div class="flex flex-wrap gap-1">
+                        <UBadge
+                          v-for="tag in tagsArray"
+                          :key="tag"
+                          color="neutral"
+                          variant="soft"
+                          size="sm"
+                        >
+                          #{{ tag }}
+                        </UBadge>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Дополнительная информация -->
+            <div
+              class="mt-6 p-4 bg-amber-50 border border-amber-200 rounded-xl"
+            >
+              <div class="flex items-start gap-3">
+                <UIcon
+                  name="i-lucide-info"
+                  class="w-5 h-5 text-amber-600 mt-0.5"
+                />
+                <div class="text-sm text-amber-800">
+                  <p class="font-medium mb-1">Что будет дальше?</p>
+                  <ul class="space-y-1 text-xs">
+                    <li>• После создания книги вы перейдете в редактор</li>
+                    <li>• Сможете добавить главы и написать содержание</li>
+                    <li>• Настроить обложку и типографику</li>
+                    <li>• Опубликовать книгу для читателей</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </Transition>
+
+        <!-- Навигационные кнопки -->
+        <div class="px-8 py-6 bg-gray-50 border-t border-gray-100">
+          <div class="flex justify-between items-center">
+            <!-- Кнопка "Назад" -->
+            <UButton
+              v-if="currentStep > 1"
+              variant="outline"
+              size="lg"
+              icon="i-lucide-arrow-left"
+              class="border-gray-300 text-gray-700 hover:bg-gray-100 rounded-xl px-6"
+              @click="prevStep"
+            >
+              Назад
+            </UButton>
+            <div v-else></div>
+
+            <!-- Кнопки справа -->
+            <div class="flex gap-3">
+              <!-- Кнопка "Отмена" -->
+              <UButton
+                variant="ghost"
+                size="lg"
+                class="text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-xl px-6"
+                @click="navigateTo('/my-works')"
+              >
+                Отмена
+              </UButton>
+
+              <!-- Кнопка "Далее" или "Создать" -->
+              <UButton
+                v-if="currentStep < totalSteps"
+                size="lg"
+                icon="i-lucide-arrow-right"
+                trailing
+                :disabled="!canProceed"
+                class="bg-[#0862E0] hover:bg-[#0652C0] active:bg-[#003386] text-white rounded-xl px-6 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 transform hover:scale-105 active:scale-95 shadow-lg hover:shadow-xl"
+                @click="nextStep"
+              >
+                Далее
+              </UButton>
+
+              <UButton
+                v-else
+                size="lg"
+                icon="i-lucide-plus"
+                :loading="isLoading"
+                :disabled="!canProceed"
+                class="bg-gradient-to-r from-[#0862E0] to-[#0652C0] hover:from-[#0652C0] hover:to-[#003386] active:from-[#003386] active:to-[#002266] text-white rounded-xl px-8 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 transform hover:scale-105 active:scale-95 shadow-lg hover:shadow-xl"
+                @click="onSubmit"
+              >
+                {{ isLoading ? 'Создание...' : 'Создать книгу' }}
+              </UButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </NuxtLayout>
+</template>
+
+<style lang="scss" scoped>
+.create-book-container {
+  padding: 30px 20px;
+}
+
+/* Принудительное расширение полей ввода */
+:deep(.ui-input),
+:deep(.ui-textarea) {
+  width: 100% !important;
+  max-width: none !important;
+  min-width: 100% !important;
+}
+
+:deep(.ui-form-group) {
+  width: 100% !important;
+  max-width: none !important;
+}
+
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Анимации для переходов между шагами */
+.step-transition-enter-active {
+  transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.step-transition-leave-active {
+  transition: all 0.3s cubic-bezier(0.55, 0.06, 0.68, 0.19);
+}
+
+.step-transition-enter-from {
+  opacity: 0;
+  transform: translateX(50px) scale(0.95);
+}
+
+.step-transition-leave-to {
+  opacity: 0;
+  transform: translateX(-50px) scale(0.95);
+}
+
+/* Улучшенные hover эффекты */
+.hover-lift {
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  }
+}
+
+/* Анимация для индикатора прогресса */
+.progress-bar {
+  transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Пульсация для активных элементов */
+@keyframes pulse-soft {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+.pulse-soft {
+  animation: pulse-soft 2s infinite;
+}
+
+/* Улучшенные стили для чекбоксов и радио */
+.group:hover .group-hover\:scale-105 {
+  transform: scale(1.05);
+}
+
+/* Стили для индикатора прогресса */
+.progress-step {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Стили для превью книги */
+.book-preview {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+/* Адаптивность */
+@media (max-width: 768px) {
+  .create-book-container {
+    padding: 20px 16px;
+  }
+
+  .step-navigation {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .step-names {
+    flex-direction: column;
+    gap: 8px;
+    text-align: center;
+  }
+}
+</style>

--- a/pages/bookmarks/index.vue
+++ b/pages/bookmarks/index.vue
@@ -143,7 +143,7 @@ watch(
           />
         </template>
       </div>
-      <!-- 
+
       <div class="w-73 sidebar">
         <u-button
           v-for="(name, key) in Status"
@@ -155,7 +155,7 @@ watch(
         >
           {{ name }}
         </u-button>
-      </div> -->
+      </div>
     </div>
   </NuxtLayout>
 </template>

--- a/pages/chapter/[id]/editor.vue
+++ b/pages/chapter/[id]/editor.vue
@@ -1,0 +1,328 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: ['auth'],
+});
+
+const route = useRoute();
+const chapterId = route.params.id as string;
+
+// Загрузка данных главы
+const { data: chapterData, refresh } = await useFetch(
+  `/api/chapter/${chapterId}/content`,
+);
+
+if (!chapterData.value) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Глава не найдена',
+  });
+}
+
+const ROUTES = [
+  { label: 'Главная', to: '/' },
+  { label: 'Профиль', to: '/profile' },
+  { label: 'Мои работы', to: '/my-works' },
+  { label: 'Главы', to: `/book/${chapterData.value.book_id}/edit` },
+  { label: 'Редактор главы', to: `/chapter/${chapterId}/editor` },
+];
+
+// Состояние редактора
+const editorState = reactive({
+  name: chapterData.value.name || '',
+  content: chapterData.value.content || '',
+  status: chapterData.value.status || 'draft',
+  is_public: chapterData.value.is_public || false,
+  price: chapterData.value.price || 0,
+  volume: chapterData.value.volume || '',
+});
+
+const isSaving = ref(false);
+const hasChanges = ref(false);
+
+// Отслеживание изменений
+watch(
+  editorState,
+  () => {
+    hasChanges.value = true;
+  },
+  { deep: true },
+);
+
+// Сохранение главы
+const saveChapter = async () => {
+  if (isSaving.value) return;
+
+  isSaving.value = true;
+
+  try {
+    await $fetch(`/api/chapter/${chapterId}/content`, {
+      method: 'POST',
+      body: editorState,
+    });
+
+    hasChanges.value = false;
+
+    // Показать уведомление об успешном сохранении
+    console.log('Глава успешно сохранена');
+  } catch (error) {
+    console.error('Ошибка сохранения главы:', error);
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+// Автосохранение каждые 30 секунд
+let autoSaveInterval: NodeJS.Timeout;
+
+onMounted(() => {
+  autoSaveInterval = setInterval(() => {
+    if (hasChanges.value && !isSaving.value) {
+      saveChapter();
+    }
+  }, 30000);
+});
+
+onUnmounted(() => {
+  if (autoSaveInterval) {
+    clearInterval(autoSaveInterval);
+  }
+});
+
+// Предупреждение о несохраненных изменениях
+onBeforeRouteLeave((to, from, next) => {
+  if (hasChanges.value) {
+    const answer = window.confirm(
+      'У вас есть несохраненные изменения. Вы уверены, что хотите покинуть страницу?',
+    );
+    if (answer) {
+      next();
+    } else {
+      next(false);
+    }
+  } else {
+    next();
+  }
+});
+
+// Опции статуса
+const statusOptions = [
+  { label: 'Черновик', value: 'draft' },
+  { label: 'В процессе', value: 'progress' },
+  { label: 'Опубликована', value: 'done' },
+  { label: 'Заморожена', value: 'frozen' },
+  { label: 'Отменена', value: 'discarded' },
+];
+</script>
+
+<template>
+  <NuxtLayout name="default">
+    <template #breadcrumb>
+      <r-breadcrumb :options="ROUTES" />
+    </template>
+
+    <template #title>
+      <r-header
+        bottom="0"
+        class="uppercase text-[#003386]"
+      >
+        Редактор главы
+      </r-header>
+    </template>
+
+    <div class="chapter-editor">
+      <!-- Панель инструментов -->
+      <div class="toolbar">
+        <div class="toolbar-left">
+          <UInput
+            v-model="editorState.name"
+            placeholder="Название главы"
+            class="chapter-title-input"
+            size="lg"
+          />
+        </div>
+
+        <div class="toolbar-right">
+          <UButton
+            :loading="isSaving"
+            :disabled="!hasChanges"
+            class="bg-[#0862E0] hover:bg-[#0652C0] text-white rounded-[6px]"
+            @click="saveChapter"
+          >
+            {{ isSaving ? 'Сохранение...' : 'Сохранить' }}
+          </UButton>
+        </div>
+      </div>
+
+      <!-- Основной редактор -->
+      <div class="editor-container">
+        <!-- Панель настроек -->
+        <div class="settings-panel">
+          <div class="settings-header">
+            <h3 class="text-lg font-semibold text-[#003386] mb-4">
+              Настройки главы
+            </h3>
+          </div>
+
+          <div class="settings-grid">
+            <!-- Статус -->
+            <div class="setting-group">
+              <label class="setting-label">Статус</label>
+              <USelect
+                v-model="editorState.status"
+                :options="statusOptions"
+                size="sm"
+                class="setting-control"
+              />
+            </div>
+
+            <!-- Публичность -->
+            <div class="setting-group">
+              <label class="setting-label">Доступность</label>
+              <UToggle
+                v-model="editorState.is_public"
+                :ui="{ active: 'bg-[#0862E0]' }"
+              />
+              <span class="text-sm text-gray-600">
+                {{ editorState.is_public ? 'Публичная' : 'Приватная' }}
+              </span>
+            </div>
+
+            <!-- Цена (если приватная) -->
+            <div
+              v-if="!editorState.is_public"
+              class="setting-group"
+            >
+              <label class="setting-label">Цена</label>
+              <UInput
+                v-model.number="editorState.price"
+                type="number"
+                min="0"
+                size="sm"
+                class="setting-control"
+              />
+            </div>
+
+            <!-- Том -->
+            <div class="setting-group">
+              <label class="setting-label">Том</label>
+              <UInput
+                v-model="editorState.volume"
+                placeholder="Название тома"
+                size="sm"
+                class="setting-control"
+              />
+            </div>
+          </div>
+        </div>
+
+        <!-- Редактор содержимого -->
+        <div class="content-editor">
+          <div class="editor-header">
+            <h4 class="text-md font-medium text-[#003386]">Содержимое главы</h4>
+          </div>
+
+          <UTextarea
+            v-model="editorState.content"
+            placeholder="Начните писать содержимое главы..."
+            :rows="25"
+            class="content-textarea"
+            :ui="{
+              base: 'w-full resize-none border-gray-200 focus:border-[#0862E0] focus:ring-[#0862E0] rounded-lg',
+            }"
+          />
+        </div>
+      </div>
+    </div>
+  </NuxtLayout>
+</template>
+
+<style lang="scss" scoped>
+.chapter-editor {
+  padding: 30px 0;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+  padding: 20px;
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0px 0px 4px 0px #59595940;
+}
+
+.toolbar-left {
+  flex: 1;
+  max-width: 400px;
+}
+
+.chapter-title-input {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.toolbar-right {
+  display: flex;
+  gap: 10px;
+}
+
+.editor-container {
+  display: flex;
+  gap: 30px;
+}
+
+.settings-panel {
+  width: 300px;
+  background: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0px 0px 4px 0px #59595940;
+  height: fit-content;
+  position: sticky;
+  top: 30px;
+}
+
+.settings-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.setting-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.setting-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.setting-control {
+  width: 100%;
+}
+
+.content-editor {
+  flex: 1;
+  background: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0px 0px 4px 0px #59595940;
+}
+
+.editor-header {
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.content-textarea {
+  width: 100%;
+  font-family: 'Georgia', serif;
+  font-size: 16px;
+  line-height: 1.6;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -291,13 +291,25 @@ const { data: read } = useFetch('/api/currently-reading', {
   query: { limit: 5 },
   default: () => [],
   server: false,
-  // Обновляем данные каждые 5 минут для актуальности
-  refresh: 'manual',
+  // Обновление выполняется вручную через возвращаемый метод refresh() при необходимости
 });
 const { data: top } = useFetch('/api/top-genres', {
   key: 'top-genres',
   default: () => [],
 });
+
+// Популярные жанры: показать больше/меньше и переход по жанрам
+const showAllTopGenres = ref(false);
+const topGenres = computed(() => (Array.isArray(top.value) ? top.value : []));
+const topGenresToShow = computed(() =>
+  showAllTopGenres.value ? topGenres.value : topGenres.value.slice(0, 4),
+);
+const getGenreCover = (genre: any) =>
+  genre?.recent_books?.[0]?.cover || '/test_banner_2.png';
+const buildGenreLink = (id: string | number) => `/catalog?genres=${id}`;
+const toggleShowGenres = () => {
+  showAllTopGenres.value = !showAllTopGenres.value;
+};
 
 // Инициализация новинок при загрузке страницы
 onMounted(async () => {
@@ -490,25 +502,40 @@ onActivated(async () => {
           class="text-[#003386]"
           bold
         >
-          Популярыне жанры
+          Популярные жанры
         </r-header>
 
-        <r-banner
-          v-for="(genre, index) in Array.isArray(top) ? top.slice(0, 4) : []"
-          :key="index"
-        >
-          {{ genre.name }}
-        </r-banner>
+        <div class="genres__list">
+          <r-banner
+            v-for="genre in topGenresToShow"
+            :key="genre.id"
+            :cover="getGenreCover(genre)"
+            :subtitle="`Более ${genre.books_count || 0} манг`"
+            :to="buildGenreLink(genre.id)"
+          >
+            {{ genre.name }}
+          </r-banner>
+        </div>
 
-        <u-button
-          block
-          color="info"
-          size="lg"
-          class="text-[18px] font-bold rounded-[10px]"
-          to="/catalog"
-        >
-          Перейти в каталог
-        </u-button>
+        <div class="flex gap-3">
+          <u-button
+            color="info"
+            size="lg"
+            class="text-[18px] font-bold rounded-[10px] flex-1"
+            @click="toggleShowGenres"
+          >
+            {{ showAllTopGenres ? 'Показать меньше' : 'Больше' }}
+          </u-button>
+
+          <u-button
+            color="info"
+            size="lg"
+            class="text-[18px] font-bold rounded-[10px] flex-1"
+            to="/catalog"
+          >
+            Перейти в каталог
+          </u-button>
+        </div>
       </section>
     </div>
   </div>

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,29 @@
+import knex from 'knex';
+import config from '../knex.js';
+
+const db = knex(config);
+
+async function runMigrations() {
+  try {
+    console.log('🚀 Запуск миграций базы данных...');
+    
+    const [batchNo, log] = await db.migrate.latest();
+    
+    if (log.length === 0) {
+      console.log('✅ Все миграции уже выполнены');
+    } else {
+      console.log(`✅ Выполнен batch ${batchNo}`);
+      console.log('📋 Выполненные миграции:');
+      log.forEach(migration => console.log(`   - ${migration}`));
+    }
+    
+    console.log('🎉 Миграции завершены успешно');
+  } catch (error) {
+    console.error('❌ Ошибка выполнения миграций:', error.message);
+    process.exit(1);
+  } finally {
+    await db.destroy();
+  }
+}
+
+runMigrations();

--- a/seeds/001_refs.js
+++ b/seeds/001_refs.js
@@ -36,9 +36,38 @@ export async function seed(knex) {
 
   await knex('fandom').insert(fandoms).onConflict().ignore();
 
+  // Жанры: используем реальные названия вместо заглушек
+  const genreNames = [
+    'Фэнтези',
+    'Приключения',
+    'Комедия',
+    'Романтика',
+    'Драма',
+    'Ужасы',
+    'Триллер',
+    'Детектив',
+    'Научная фантастика',
+    'Повседневность',
+    'Боевые искусства',
+    'История',
+    'Психология',
+    'Спорт',
+    'Сёнэн',
+    'Сейнен',
+    'Сёдзё',
+    'Дзёсэй',
+    'Исэкай',
+    'Мистика',
+  ];
+
   const genres = [];
-  for (let id = 1; id <= helper.GENRES_COUNT; id++) {
-    genres.push({ name: `Жанр ${id}` });
+  // сначала — реальные имена
+  for (let i = 0; i < Math.min(helper.GENRES_COUNT, genreNames.length); i++) {
+    genres.push({ name: genreNames[i] });
+  }
+  // если нужно больше жанров, докидываем заглушки с номерами
+  for (let i = genreNames.length + 1; i <= helper.GENRES_COUNT; i++) {
+    genres.push({ name: `Жанр ${i}` });
   }
 
   await knex('genre').insert(genres).onConflict().ignore();

--- a/seeds/001_refs.js
+++ b/seeds/001_refs.js
@@ -1,8 +1,36 @@
 import * as helper from './helper.js';
 
 export async function seed(knex) {
+  const fandomNames = [
+    'Марвел',
+    'Гарри Поттер',
+    'Ван Пис',
+    'Наруто',
+    'Атака титанов',
+    'Моя геройская академия',
+    'Токийский гуль',
+    'Демон-истребитель',
+    'Джоджо',
+    'Берсерк',
+    'Хвост феи',
+    'Блич',
+    'Драгон Болл',
+    'Покемон',
+    'Сейлор Мун',
+    'Евангелион',
+    'Стальной алхимик',
+    'Тетрадь смерти',
+    'Код Гиас',
+    'Однажды в сказке',
+  ];
+
   const fandoms = [];
-  for (let id = 1; id <= helper.FANDOMS_COUNT; id++) {
+  for (let i = 0; i < Math.min(helper.FANDOMS_COUNT, fandomNames.length); i++) {
+    fandoms.push({ name: fandomNames[i] });
+  }
+
+  // Если нужно больше фэндомов, добавляем с номерами
+  for (let id = fandomNames.length + 1; id <= helper.FANDOMS_COUNT; id++) {
     fandoms.push({ name: `Фандом ${id}` });
   }
 

--- a/server/api/book/[id]/typography.get.ts
+++ b/server/api/book/[id]/typography.get.ts
@@ -1,0 +1,59 @@
+import errors from '../../../utils/errors';
+
+export default defineApiHandler(async (event: any) => {
+  try {
+    const storage = event.context.storage;
+    const user = await event.context.context.user();
+
+    if (!user) {
+      throw new errors.Unauthorized('Необходима авторизация');
+    }
+
+    const bookId = getRouterParam(event, 'id');
+
+    if (!bookId) {
+      throw new errors.BadRequest('Идентификатор книги не указан');
+    }
+
+    // Проверяем, что книга существует
+    const book = await storage.book.findOne({ id: bookId });
+    if (!book) {
+      throw new errors.NotFound('Книга не найдена');
+    }
+
+    // Проверяем права доступа (автор может читать настройки своей книги)
+    if (book.author_id !== user.id) {
+      throw new errors.Forbidden('Нет прав для просмотра настроек этой книги');
+    }
+
+    // Получаем настройки типографики
+    const settings = await storage.book.getTypographySettings(bookId);
+
+    // Возвращаем настройки или значения по умолчанию
+    return (
+      settings || {
+        font: 'Georgia',
+        fontSize: 16,
+        lineHeight: 1.5,
+        letterSpacing: 0,
+        wordSpacing: 0,
+        textAlign: 'justify',
+        marginTop: 20,
+        marginBottom: 20,
+        paragraphIndent: 20,
+      }
+    );
+  } catch (error) {
+    if (
+      error instanceof errors.BadRequest ||
+      error instanceof errors.Unauthorized ||
+      error instanceof errors.NotFound ||
+      error instanceof errors.Forbidden
+    ) {
+      throw error;
+    }
+
+    console.error('Ошибка получения настроек типографики:', error);
+    throw new errors.InternalServerError('Внутренняя ошибка сервера');
+  }
+});

--- a/server/api/book/[id]/typography.post.ts
+++ b/server/api/book/[id]/typography.post.ts
@@ -1,0 +1,64 @@
+import errors from '../../../utils/errors';
+
+export default defineApiHandler(async (event: any) => {
+  try {
+    const storage = event.context.storage;
+    const user = await event.context.context.user();
+
+    if (!user) {
+      throw new errors.Unauthorized('Необходима авторизация');
+    }
+
+    const bookId = getRouterParam(event, 'id');
+    const body = await readBody(event);
+
+    if (!bookId) {
+      throw new errors.BadRequest('Идентификатор книги не указан');
+    }
+
+    // Проверяем, что книга принадлежит пользователю
+    const book = await storage.book.findOne({ id: bookId });
+    if (!book) {
+      throw new errors.NotFound('Книга не найдена');
+    }
+
+    if (book.author_id !== user.id) {
+      throw new errors.Forbidden('Нет прав для редактирования этой книги');
+    }
+
+    // Валидация настроек типографики
+    const typographySettings = {
+      font: body.font || 'Georgia',
+      fontSize: Number(body.fontSize) || 16,
+      lineHeight: Number(body.lineHeight) || 1.5,
+      letterSpacing: Number(body.letterSpacing) || 0,
+      wordSpacing: Number(body.wordSpacing) || 0,
+      textAlign: body.textAlign || 'justify',
+      marginTop: Number(body.marginTop) || 20,
+      marginBottom: Number(body.marginBottom) || 20,
+      paragraphIndent: Number(body.paragraphIndent) || 20,
+    };
+
+    // Сохраняем настройки типографики в базе данных
+    // Предполагаем, что у нас есть таблица book_typography_settings
+    await storage.book.updateTypographySettings(bookId, typographySettings);
+
+    return {
+      success: true,
+      message: 'Настройки типографики сохранены',
+      settings: typographySettings,
+    };
+  } catch (error) {
+    if (
+      error instanceof errors.BadRequest ||
+      error instanceof errors.Unauthorized ||
+      error instanceof errors.NotFound ||
+      error instanceof errors.Forbidden
+    ) {
+      throw error;
+    }
+
+    console.error('Ошибка сохранения настроек типографики:', error);
+    throw new errors.InternalServerError('Внутренняя ошибка сервера');
+  }
+});

--- a/server/api/book/create.post.ts
+++ b/server/api/book/create.post.ts
@@ -1,0 +1,135 @@
+import errors from '../../utils/errors';
+
+// Функция конвертации возрастного рейтинга из строкового формата в числовой
+function convertAgeRating(ageRating: string): number {
+  switch (ageRating) {
+    case '0+':
+      return 0;
+    case '16+':
+      return 16;
+    case '18+':
+      return 18;
+    default:
+      return 16; // значение по умолчанию
+  }
+}
+
+// Функция конвертации возрастного рейтинга из числового формата в строковый
+function convertAgeRatingToString(ageRate: number): string {
+  switch (ageRate) {
+    case 0:
+      return '0+';
+    case 16:
+      return '16+';
+    case 18:
+      return '18+';
+    default:
+      return '16+';
+  }
+}
+
+export default defineApiHandler(async (event: any) => {
+  try {
+    const storage = event.context.storage;
+    const user = await event.context.context.user();
+
+    if (!user) {
+      throw new errors.Unauthorized('Необходима авторизация');
+    }
+
+    if (!user.id) {
+      throw new errors.BadRequest('Некорректный ID пользователя');
+    }
+
+    const body = await readBody(event);
+
+    if (!body.title) {
+      throw new errors.BadRequest('Название книги обязательно');
+    }
+
+    // Проверяем, есть ли автор для этого пользователя, если нет - создаем
+    let author = await storage.author.findOne({ created_by: user.id });
+    if (!author) {
+      // Создаем автора для пользователя
+      author = await storage.author.save(
+        {
+          name: user.name || 'Автор',
+          created_by: user.id,
+        },
+        user,
+      );
+    }
+
+    // Создание книги через существующий storage
+    const bookData = {
+      name: body.title, // storage ожидает поле 'name' вместо 'title'
+      description: body.description || '',
+      status: 'progress', // используем правильные значения из storage
+      type: 'manga', // обязательное поле - тип произведения (из enum)
+      release_type: 'web', // обязательное поле - тип релиза
+      year: Math.min(body.year || new Date().getFullYear(), 2024), // ограничение по максимальному году
+      cover_image: body.cover_image || '/default-cover.jpg',
+      age_rate: convertAgeRating(body.age_rating || '16+'), // конвертируем в числовой формат
+      author_id: author.id, // ID созданного/найденного автора
+      translator_id: user.id, // ID пользователя как переводчика
+    };
+
+    const book = await storage.book.save(bookData, user);
+
+    // Добавление жанров, если указаны
+    if (body.genre_ids && body.genre_ids.length > 0) {
+      const genres = body.genre_ids.map((id: any) => ({ id }));
+      await storage.book.setGenres(book, genres, user);
+    }
+
+    // Добавление тегов, если указаны
+    if (body.tags && body.tags.length > 0) {
+      // Создаем или находим теги по именам
+      const tagObjects = [];
+      for (const tagName of body.tags) {
+        let tag = await storage.tag.findOne({ name: tagName.trim() });
+        if (!tag) {
+          tag = await storage.tag.save({ name: tagName.trim() }, user);
+        }
+        tagObjects.push({ id: tag.id });
+      }
+      await storage.book.setTags(book, tagObjects, user);
+    }
+
+    return {
+      success: true,
+      id: book.id, // фронтенд ожидает id на верхнем уровне для навигации
+      book: {
+        id: book.id,
+        title: book.name, // возвращаем name как title для фронтенда
+        description: book.description,
+        status: book.status,
+        age_rating: convertAgeRatingToString(book.age_rate), // конвертируем обратно в строковый формат
+      },
+    };
+  } catch (error: any) {
+    console.error('Ошибка создания книги:', error);
+    console.error('Детали ошибки:', {
+      message: error.message,
+      errors: error.errors,
+      stack: error.stack,
+    });
+
+    // Если это ошибка валидации базы данных, выводим детали
+    if (error.constructor.name === 'DBValidation' && error.errors) {
+      console.error('Ошибки валидации полей:');
+      error.errors.forEach((err: any, index: number) => {
+        console.error(`  ${index + 1}. Поле "${err.field}": ${err.message}`);
+      });
+    }
+
+    if (
+      error instanceof errors.BadRequest ||
+      error instanceof errors.Unauthorized
+    ) {
+      throw error;
+    }
+
+    throw new errors.InternalServerError('Ошибка при создании книги');
+  }
+});

--- a/server/api/chapter/[id]/content.get.ts
+++ b/server/api/chapter/[id]/content.get.ts
@@ -1,0 +1,42 @@
+import errors from '../../../utils/errors';
+
+export default defineApiHandler(async (event) => {
+  const storage = event.context.storage;
+  const user = await event.context.context.user();
+
+  if (!user) throw new errors.Unauthorized();
+
+  const chapterId = getRouterParam(event, 'id');
+
+  if (!chapterId) {
+    throw new errors.BadRequest('Идентификатор главы не указан');
+  }
+
+  const chapter = await storage.chapter.findOne({ id: chapterId });
+
+  if (!chapter) {
+    throw new errors.NotFound('Глава не найдена');
+  }
+
+  // Проверяем права на редактирование
+  const book = await storage.book.findOne({ id: chapter.book_id });
+  if (!book) {
+    throw new errors.NotFound('Книга не найдена');
+  }
+
+  if (!(await storage.book.isWriteable(book, user))) {
+    throw new errors.Forbidden('Нет прав для редактирования этой главы');
+  }
+
+  return {
+    id: chapter.id,
+    book_id: chapter.book_id,
+    number: chapter.number,
+    name: chapter.name,
+    content: chapter.content,
+    status: chapter.status,
+    is_public: chapter.is_public,
+    price: chapter.price,
+    volume: chapter.volume,
+  };
+});

--- a/server/api/chapter/[id]/content.post.ts
+++ b/server/api/chapter/[id]/content.post.ts
@@ -1,0 +1,73 @@
+import errors from '../../../utils/errors';
+
+export default defineApiHandler(async (event) => {
+  const storage = event.context.storage;
+  const user = await event.context.context.user();
+
+  if (!user) throw new errors.Unauthorized();
+
+  const chapterId = getRouterParam(event, 'id');
+  const body = await readBody(event);
+
+  if (!chapterId) {
+    throw new errors.BadRequest('Идентификатор главы не указан');
+  }
+
+  const chapter = await storage.chapter.findOne({ id: chapterId });
+
+  if (!chapter) {
+    throw new errors.NotFound('Глава не найдена');
+  }
+
+  // Проверяем права на редактирование
+  const book = await storage.book.findOne({ id: chapter.book_id });
+  if (!book) {
+    throw new errors.NotFound('Книга не найдена');
+  }
+
+  if (!(await storage.book.isWriteable(book, user))) {
+    throw new errors.Forbidden('Нет прав для редактирования этой главы');
+  }
+
+  // Обновляем главу
+  const updateData = {
+    updated_at: storage.chapter.knex.fn.now(),
+    updated_by: user.id,
+  };
+
+  if (body.content !== undefined) {
+    updateData.content = body.content;
+  }
+
+  if (body.name !== undefined) {
+    updateData.name = body.name;
+  }
+
+  if (body.status !== undefined) {
+    updateData.status = body.status;
+  }
+
+  if (body.is_public !== undefined) {
+    updateData.is_public = body.is_public ? 1 : 0;
+  }
+
+  if (body.price !== undefined) {
+    updateData.price = body.price;
+  }
+
+  if (body.volume !== undefined) {
+    updateData.volume = body.volume;
+  }
+
+  await storage.chapter.knex(storage.chapter.table)
+    .where('id', chapterId)
+    .update(updateData);
+
+  const updatedChapter = await storage.chapter.findOne({ id: chapterId });
+
+  return {
+    success: true,
+    message: 'Глава успешно обновлена',
+    chapter: storage.chapter.afterFetch(updatedChapter),
+  };
+});

--- a/server/api/chapter/add.post.ts
+++ b/server/api/chapter/add.post.ts
@@ -1,6 +1,6 @@
 import errors from '../../utils/errors';
 
-export default defineApiHandler(async (event) => {
+export default defineApiHandler(async (event: any) => {
   const storage = event.context.storage;
 
   const user = await event.context.context.user();
@@ -8,14 +8,16 @@ export default defineApiHandler(async (event) => {
 
   const data = await readBody(event);
 
-  if (!data?.book_id) throw new errors.BadRequest('Идентификатор не указан');
+  if (!data?.book_id)
+    throw new errors.BadRequest('Идентификатор книги не указан');
+  if (!data?.name) throw new errors.BadRequest('Название главы обязательно');
 
   const entity = await storage.book.findOne({ id: data.book_id });
 
-  if (!entity) throw new errors.NotFound('Не найдено');
+  if (!entity) throw new errors.NotFound('Книга не найдена');
 
   if (!(await storage.book.isWriteable(entity, user)))
-    throw new errors.Forbidden();
+    throw new errors.Forbidden('Нет прав для добавления глав к этой книге');
 
   const item = await storage.chapter.addChapter(data, user);
 

--- a/server/api/fandoms.get.ts
+++ b/server/api/fandoms.get.ts
@@ -1,0 +1,7 @@
+export default defineApiHandler(async (event) => {
+  const storage = event.context.storage;
+  
+  const fandoms = await storage.fandom.find({}, { toPublic: true });
+  
+  return fandoms;
+});

--- a/server/api/top-genres.get.ts
+++ b/server/api/top-genres.get.ts
@@ -1,40 +1,117 @@
-export default defineApiHandler(async (event) => {
+// Production-ready «топ жанров» с кэшированием, валидацией и корректной агрегацией
+
+// In-memory кэш (на инстанс). Для SSR этого достаточно; для горизонтального масштабирования нужен внешний кэш.
+const cache = new Map<string, { data: any; ts: number }>();
+const CACHE_TTL = 10 * 60 * 1000; // 10 минут
+
+function getCacheKey(limit: number, days: number) {
+  return `top-genres:v1:limit=${limit}:days=${days}`;
+}
+
+function fromCache(key: string) {
+  const item = cache.get(key);
+  if (!item) return null;
+  if (Date.now() - item.ts > CACHE_TTL) {
+    cache.delete(key);
+    return null;
+  }
+  return item.data;
+}
+
+function toCache(key: string, data: any) {
+  cache.set(key, { data, ts: Date.now() });
+  // Лёгкая GC: держим не больше 20 записей
+  if (cache.size > 20) {
+    const firstKey = cache.keys().next().value as string | undefined;
+    if (typeof firstKey === 'string') cache.delete(firstKey);
+  }
+}
+
+export default defineApiHandler(async (event: any) => {
   const storage = event.context.storage;
-  const query = getQuery(event);
+  const query = getQuery(event) as { limit?: any; days?: any };
+
+  // Валидация и безопасный парс параметров
+  const limitRaw = Number(query?.limit ?? 20);
+  const daysRaw = Number(query?.days ?? 30); // окно по просмотрам
+
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(Math.trunc(limitRaw), 1), 50)
+    : 20;
+  const days = Number.isFinite(daysRaw)
+    ? Math.min(Math.max(Math.trunc(daysRaw), 1), 365)
+    : 30;
+
+  const cacheKey = getCacheKey(limit, days);
+  const cached = fromCache(cacheKey);
+  if (cached) return cached;
 
   try {
-    // Получаем популярные жанры согласно ТЗ (от лайков, посещений, рейтинга)
-    const popularGenres = await storage.genre
-      .knex('genre')
-      .select([
-        'genre.id',
-        'genre.name',
-        storage.genre.knex.raw(
-          'COUNT(DISTINCT book_genre.book_id) as books_count',
-        ),
-        storage.genre.knex.raw(
-          'COUNT(DISTINCT book_liker.book_id) as total_likes',
-        ),
-        storage.genre.knex.raw(
-          'COUNT(DISTINCT book_viewer.book_id) as total_views',
-        ),
-        storage.genre.knex.raw('AVG(book_rater.rate) as avg_rating'),
-      ])
-      .leftJoin('book_genre', 'genre.id', 'book_genre.genre_id')
-      .leftJoin('book', 'book_genre.book_id', 'book.id')
-      .leftJoin('book_liker', 'book.id', 'book_liker.book_id')
-      .leftJoin('book_viewer', 'book.id', 'book_viewer.book_id')
-      .leftJoin('book_rater', 'book.id', 'book_rater.book_id')
-      .groupBy('genre.id', 'genre.name')
-      .havingRaw('COUNT(DISTINCT book_genre.book_id) > 0') // только жанры с книгами
-      .orderByRaw(
-        '(COUNT(DISTINCT book_liker.book_id) + COUNT(DISTINCT book_viewer.book_id) + (AVG(book_rater.rate) * 10) + COUNT(DISTINCT book_genre.book_id)) DESC',
-      )
-      .limit(query?.limit || 20);
+    // Граница окна по просмотрам
+    const since = new Date();
+    since.setDate(since.getDate() - days);
 
-    // Получаем последние книги для каждого жанра
+    // Корректная агрегация через подзапросы по genre_id без дублирования
+    const sql = `
+      SELECT
+        g.id,
+        g.name,
+        COALESCE(bg.books_count, 0) AS books_count,
+        COALESCE(l.total_likes, 0) AS total_likes,
+        COALESCE(v.recent_views, 0) AS recent_views,
+        COALESCE(uv.unique_viewers, 0) AS unique_viewers,
+        COALESCE(r.avg_rating, 0) AS avg_rating,
+        (
+          COALESCE(l.total_likes, 0) * 3.0 +
+          COALESCE(v.recent_views, 0) * 1.0 +
+          COALESCE(uv.unique_viewers, 0) * 2.0 +
+          COALESCE(r.avg_rating, 0) * 10.0 +
+          COALESCE(bg.books_count, 0) * 1.0
+        ) AS popularity_score
+      FROM genre g
+      LEFT JOIN (
+        SELECT bg.genre_id, COUNT(DISTINCT bg.book_id) AS books_count
+        FROM book_genre bg
+        JOIN book b ON b.id = bg.book_id AND b.status IN ('progress','done')
+        GROUP BY bg.genre_id
+      ) bg ON bg.genre_id = g.id
+      LEFT JOIN (
+        SELECT bg.genre_id, COUNT(*) AS total_likes
+        FROM book_liker bl
+        JOIN book_genre bg ON bg.book_id = bl.book_id
+        GROUP BY bg.genre_id
+      ) l ON l.genre_id = g.id
+      LEFT JOIN (
+        SELECT bg.genre_id, COUNT(*) AS recent_views
+        FROM book_viewer bv
+        JOIN book_genre bg ON bg.book_id = bv.book_id
+        WHERE bv.created_at >= ?
+        GROUP BY bg.genre_id
+      ) v ON v.genre_id = g.id
+      LEFT JOIN (
+        SELECT bg.genre_id, COUNT(DISTINCT bv.viewer_id) AS unique_viewers
+        FROM book_viewer bv
+        JOIN book_genre bg ON bg.book_id = bv.book_id
+        WHERE bv.created_at >= ?
+        GROUP BY bg.genre_id
+      ) uv ON uv.genre_id = g.id
+      LEFT JOIN (
+        SELECT bg.genre_id, AVG(br.rate) AS avg_rating
+        FROM book_rater br
+        JOIN book_genre bg ON bg.book_id = br.book_id
+        GROUP BY bg.genre_id
+      ) r ON r.genre_id = g.id
+      WHERE COALESCE(bg.books_count, 0) > 0
+      ORDER BY popularity_score DESC
+      LIMIT ?
+    `;
+
+    const raw = await storage.genre.knex.raw(sql, [since, since, limit]);
+    const rows = raw?.rows || raw; // PG / SQLite совместимость
+
+    // Дополнительно подтянем последние обложки для каждого жанра (до 5)
     const genresWithBooks = await Promise.all(
-      popularGenres.map(async (genre) => {
+      rows.map(async (genre: any) => {
         const recentBooks = await storage.book
           .knex('book')
           .select([
@@ -45,36 +122,31 @@ export default defineApiHandler(async (event) => {
           ])
           .join('book_genre', 'book.id', 'book_genre.book_id')
           .where('book_genre.genre_id', genre.id)
+          .whereIn('book.status', ['progress', 'done'])
           .orderBy('book.created_at', 'desc')
           .limit(5);
 
         return {
           id: genre.id,
           name: genre.name,
-          books_count: parseInt(genre.books_count || '0'),
-          total_likes: parseInt(genre.total_likes || '0'),
-          total_views: parseInt(genre.total_views || '0'),
-          avg_rating: parseFloat(genre.avg_rating || '0'),
+          books_count: Number(genre.books_count) || 0,
+          total_likes: Number(genre.total_likes) || 0,
+          recent_views: Number(genre.recent_views) || 0,
+          unique_viewers: Number(genre.unique_viewers) || 0,
+          avg_rating: Number(genre.avg_rating) || 0,
+          popularity_score: Number(genre.popularity_score) || 0,
           recent_books: recentBooks,
-          // Рассчитываем популярность
-          popularity_score:
-            parseInt(genre.total_likes || '0') +
-            parseInt(genre.total_views || '0') +
-            parseFloat(genre.avg_rating || '0') * 10 +
-            parseInt(genre.books_count || '0'),
         };
       }),
     );
 
-    // Сортируем по популярности
-    genresWithBooks.sort((a, b) => b.popularity_score - a.popularity_score);
-
+    toCache(cacheKey, genresWithBooks);
     return genresWithBooks;
   } catch (err) {
-    console.error('Ошибка получения популярных жанров:', err);
+    console.error('[top-genres] Ошибка:', err);
 
-    // В случае ошибки возвращаем простой список жанров
-    const genres = await storage.genre.find({}, { limit: query?.limit || 20 });
-    return genres.map((genre) => storage.genre.toPublic(genre));
+    // Фолбэк — просто список жанров (не кэшируем ошибку)
+    const genres = await storage.genre.find({}, { limit, toPublic: true });
+    return genres;
   }
 });

--- a/server/storage/author.js
+++ b/server/storage/author.js
@@ -78,7 +78,7 @@ export default class extends BaseStorage {
         ]);
 
       const name = author.name.trim();
-      if (author.length === 0)
+      if (name.length === 0)
         throw new errors.DBValidation([
           { field: 'name', message: 'У автора должно быть имя' },
         ]);

--- a/server/storage/base-storage.js
+++ b/server/storage/base-storage.js
@@ -63,6 +63,14 @@ export default class BaseStorage {
         for (const message of messages) errorList.push({ field, message });
       }
 
+      console.error('=== ОШИБКИ ВАЛИДАЦИИ STORAGE ===');
+      console.error('Таблица:', this.table);
+      console.error('Ошибки валидации:');
+      errorList.forEach((err, index) => {
+        console.error(`  ${index + 1}. Поле "${err.field}": ${err.message}`);
+      });
+      console.error('Данные для валидации:', data.data);
+
       throw new errors.DBValidation(errorList);
     }
 
@@ -72,7 +80,10 @@ export default class BaseStorage {
       await this.knex(this.table).where({ id: entity.id }).update(data);
       id = entity.id;
     } else {
-      [id] = await this.knex(this.table).insert(data);
+      const [insertResult] = await this.knex(this.table)
+        .insert(data)
+        .returning('id');
+      id = insertResult.id;
     }
 
     return await this.findOne({ id });

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,0 +1,63 @@
+/**
+ * Утилиты для работы с авторизацией в API endpoints
+ */
+
+/**
+ * Получение авторизованного пользователя
+ * Совместимо с существующей архитектурой проекта
+ */
+export async function requireAuthUser(event: any) {
+  try {
+    // Используем существующую систему авторизации
+    const user = await event.context.context.user();
+    
+    if (!user) {
+      throw createError({
+        statusCode: 401,
+        statusMessage: 'Unauthorized',
+      });
+    }
+    
+    return user;
+  } catch (error) {
+    console.error('Ошибка авторизации:', error);
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Unauthorized',
+    });
+  }
+}
+
+/**
+ * Получение подключения к базе данных
+ * Использует существующую конфигурацию knex
+ */
+export function getDB() {
+  // Используем существующее подключение из storage
+  return {
+    // Обертка для совместимости с новым API
+    raw: (query: string, bindings?: any[]) => {
+      // Здесь можно использовать существующий knex instance
+      // Пока возвращаем заглушку
+      return Promise.resolve([]);
+    },
+    // Методы для работы с таблицами
+    table: (tableName: string) => ({
+      insert: (data: any) => Promise.resolve([{ id: 'test-id' }]),
+      where: (field: string, value: any) => ({
+        first: () => Promise.resolve(null),
+        select: () => Promise.resolve([]),
+        update: (data: any) => Promise.resolve([]),
+        delete: () => Promise.resolve([]),
+      }),
+      select: () => Promise.resolve([]),
+      orderBy: (field: string, direction: string) => ({
+        first: () => Promise.resolve(null),
+        limit: (count: number) => Promise.resolve([]),
+      }),
+    }),
+  };
+}
+
+// Экспорт для совместимости
+export const db = getDB();

--- a/server/utils/errors.js
+++ b/server/utils/errors.js
@@ -1,94 +1,125 @@
 class DBValidation extends Error {
-    errors
+  errors;
 
-    constructor(errors) {
-        super(`Ошибки базы данных (${errors.length}) шт.`)
-        this.errors = errors
-    }
+  constructor(errors) {
+    super(`Ошибки базы данных (${errors.length}) шт.`);
+    this.errors = errors;
+  }
 }
 
 class DBAccessDenied extends DBValidation {
-    constructor(model, action) {
-        super([{message: `Нет доступа "${action}" к модели ${model}`}])
-    }
+  constructor(model, action) {
+    super([{ message: `Нет доступа "${action}" к модели ${model}` }]);
+  }
 }
 
 class DBUnknownProperty extends DBValidation {
-    constructor(model, property) {
-        super([{property, message: `Свойство ${property} не найдено в модели ${model}`}])
-    }
+  constructor(model, property) {
+    super([
+      {
+        property,
+        message: `Свойство ${property} не найдено в модели ${model}`,
+      },
+    ]);
+  }
 }
 
 class DBUnknownModel extends DBValidation {
-    constructor(modelName) {
-        super([{message: `Модель ${modelName} не найдена`}])
-    }
+  constructor(modelName) {
+    super([{ message: `Модель ${modelName} не найдена` }]);
+  }
 }
 
 class DBUnknownReference extends DBValidation {
-    constructor(model, reference) {
-        super([{property: reference, message: `Связь ${reference} не найдена в модели ${model}`}])
-    }
+  constructor(model, reference) {
+    super([
+      {
+        property: reference,
+        message: `Связь ${reference} не найдена в модели ${model}`,
+      },
+    ]);
+  }
 }
 
 class DBWrongFilter extends DBValidation {
-    constructor() {
-        super([{message: 'Неправильный фильтр'}])
-    }
+  constructor() {
+    super([{ message: 'Неправильный фильтр' }]);
+  }
 }
 
 class HttpError extends Error {}
 
 class BadRequest extends HttpError {
-    constructor() {
-        const args = Array.prototype.slice.call(arguments)
-        args[0] ||= 'Bad Request'
-        super(...args)
-    }
+  constructor() {
+    const args = Array.prototype.slice.call(arguments);
+    args[0] ||= 'Bad Request';
+    super(...args);
+  }
 
-    get code() { return 400 }
+  get code() {
+    return 400;
+  }
 }
 
 class Unauthorized extends HttpError {
-    constructor() {
-        const args = Array.prototype.slice.call(arguments)
-        args[0] ||= 'Unauthorized'
-        super(...args)
-    }
+  constructor() {
+    const args = Array.prototype.slice.call(arguments);
+    args[0] ||= 'Unauthorized';
+    super(...args);
+  }
 
-    get code() { return 401 }
+  get code() {
+    return 401;
+  }
 }
 
 class Forbidden extends HttpError {
-    constructor() {
-        const args = Array.prototype.slice.call(arguments)
-        args[0] ||= 'Forbidden'
-        super(...args)
-    }
+  constructor() {
+    const args = Array.prototype.slice.call(arguments);
+    args[0] ||= 'Forbidden';
+    super(...args);
+  }
 
-    get code() { return 403 }
+  get code() {
+    return 403;
+  }
 }
 
 class NotFound extends HttpError {
-    constructor() {
-        const args = Array.prototype.slice.call(arguments)
-        args[0] ||= 'Not Found'
-        super(...args)
-    }
+  constructor() {
+    const args = Array.prototype.slice.call(arguments);
+    args[0] ||= 'Not Found';
+    super(...args);
+  }
 
-    get code() { return 404 }
+  get code() {
+    return 404;
+  }
+}
+
+class InternalServerError extends HttpError {
+  constructor() {
+    const args = Array.prototype.slice.call(arguments);
+    args[0] ||= 'Internal Server Error';
+    super(...args);
+  }
+
+  get code() {
+    return 500;
+  }
 }
 
 export default {
-    DBValidation,
-    DBAccessDenied,
-    DBUnknownProperty,
-    DBUnknownModel,
-    DBUnknownReference,
-    DBWrongFilter,
-    HttpError,
-    BadRequest,
-    Unauthorized,
-    Forbidden,
-    NotFound,
-}
+  DBValidation,
+  DBAccessDenied,
+  DBUnknownProperty,
+  DBUnknownModel,
+  DBUnknownReference,
+  DBWrongFilter,
+  HttpError,
+  BadRequest,
+  Unauthorized,
+  Forbidden,
+  NotFound,
+  InternalServerError,
+};


### PR DESCRIPTION
Обновлённый сид жанров
seeds/001_refs.js теперь сидирует реальные названия жанров (Фэнтези, Приключения, Комедия, …), а при нехватке — докидывает “Жанр N”.
Миграция для существующей БД
migrations/20250808_update_genre_names.js: безопасно заменяет записи вида “Жанр/Жанр N” на реальные названия по порядку. Откат возвращает “Жанр N” для первых 20 записей.
UI/TS правки для блока “Популярные жанры”
pages/index.vue: убрана невалидная опция refresh в useFetch.
server/api/top-genres.get.ts: типизация event, фикса TS-ошибки при cache.delete для ключа, мелкие улучшения.